### PR TITLE
feat(controllers): add various kubernetes controllers

### DIFF
--- a/cmd/main.go
+++ b/cmd/main.go
@@ -21,7 +21,10 @@ import (
 	"openebs.io/metac/start"
 
 	blockdeviceset "mayadata.io/d-operators/controller/blockdevice/set"
+	"mayadata.io/d-operators/controller/cstorpoolauto"
 	directorhttp "mayadata.io/d-operators/controller/director/http"
+	cspcaprecommendation "mayadata.io/d-operators/controller/director/recommendations/cstorpool/capacity"
+	"mayadata.io/d-operators/controller/doperator"
 	"mayadata.io/d-operators/controller/http"
 )
 
@@ -40,9 +43,17 @@ import (
 //	One can consider each registered function as an independent
 // kubernetes controller & this project as the operator.
 func main() {
-	generic.AddToInlineRegistry("sync/blockdeviceset", blockdeviceset.Sync)
-	generic.AddToInlineRegistry("sync/directorhttp", directorhttp.Sync)
-	generic.AddToInlineRegistry("sync/http", http.Sync)
-
+	// controller name & corresponding controller reconcile function
+	var controllers = map[string]func(*generic.SyncHookRequest, *generic.SyncHookResponse) error{
+		"sync/blockdeviceset":       blockdeviceset.Sync,
+		"sync/directorhttp":         directorhttp.Sync,
+		"sync/http":                 http.Sync,
+		"sync/cstorpoolauto":        cstorpoolauto.Sync,
+		"sync/cspcaprecommendation": cspcaprecommendation.Sync,
+		"sync/doperator":            doperator.Sync,
+	}
+	for name, ctrl := range controllers {
+		generic.AddToInlineRegistry(name, ctrl)
+	}
 	start.Start()
 }

--- a/common/controller/reconciler.go
+++ b/common/controller/reconciler.go
@@ -77,6 +77,9 @@ func (r *Reconciler) logSyncFinish() {
 // updateWatchStatus updates the watch's status fields
 func (r *Reconciler) updateWatchStatus() {
 	var status = map[string]interface{}{}
+	var completion = map[string]interface{}{
+		"state": false,
+	}
 	var warn string
 	if r.Err != nil {
 		status["phase"] = "Error"
@@ -94,6 +97,13 @@ func (r *Reconciler) updateWatchStatus() {
 	if warn != "" {
 		status["warn"] = warn
 	}
+	observedAttachments := r.HookRequest.Attachments.Len()
+	desiredAttachments := len(r.HookResponse.Attachments)
+	if r.Err == nil && observedAttachments == desiredAttachments {
+		completion["state"] = true
+	}
+	// set completion against the status
+	status["completion"] = completion
 	// set the desired status
 	r.HookResponse.Status = status
 }

--- a/config/metac.yaml
+++ b/config/metac.yaml
@@ -6,14 +6,24 @@ metadata:
   name: sync-blockdeviceset
   namespace: dope
 spec:
+  # resource with kind BlockDeviceSet is watched
   watch:
     apiVersion: dao.mayadata.io/v1alpha1
     resource: blockdevicesets
+  # following resources are either read or applied:
+  #
+  # - BlockDevice (applied)
   attachments:
   - apiVersion: openebs.io/v1alpha1
     resource: blockdevices
-    updateStrategy:
-      method: InPlace
+    advancedSelector:
+      selectorTerms:
+      - matchReferenceExpressions:
+        # select BlockDevice resources if its annotation
+        #
+        # matches BlockDeviceSet _(read watch)_ UID
+        - key: metadata.annotations.blockdeviceset\.dao\.mayadata\.io/uid
+          refKey: metadata.uid
   hooks:
     sync:
       inline:
@@ -27,14 +37,34 @@ metadata:
   name: sync-directorhttp
   namespace: dope
 spec:
+  # resource with kind DirectorHTTP is watched
   watch:
     apiVersion: dao.mayadata.io/v1alpha1
     resource: directorhttps
+  # following resources are either read or applied:
+  #
+  # - HTTPData (read)
+  # - HTTP (applied)
   attachments:
   - apiVersion: dao.mayadata.io/v1alpha1
+    resource: httpdatas
+    advancedSelector:
+      selectorTerms:
+      - matchReferenceExpressions:
+        # select HTTPData resources if its name
+        # matches DirectorHTTP _(read watch)_ spec.httpDataName
+        - key: metadata.name
+          refKey: spec.httpDataName
+  - apiVersion: dao.mayadata.io/v1alpha1
     resource: https
-    updateStrategy:
-      method: InPlace
+    advancedSelector:
+      selectorTerms:
+      - matchReferenceExpressions:
+        # select HTTP resources if its annotation
+        # directorhttp.dao.mayadata.io/uid matches 
+        # DirectorHTTP _(read watch)_ UID
+        - key: metadata.annotations.directorhttp\.dao\.mayadata\.io/uid
+          refKey: metadata.uid
   hooks:
     sync:
       inline:
@@ -48,6 +78,7 @@ metadata:
   name: sync-http
   namespace: dope
 spec:
+  # resource with kind HTTP is watched
   watch:
     apiVersion: dao.mayadata.io/v1alpha1
     resource: https
@@ -56,3 +87,148 @@ spec:
       inline:
         funcName: sync/http
 ---
+apiVersion: metac.openebs.io/v1alpha1
+kind: GenericController
+metadata:
+  # namespace & name combination should be unique
+  # across all the GenericControllers in this file
+  name: sync-cspcaprecommendation
+  namespace: dope
+spec:
+  # resource with kind CStorPoolCapacityRecommendation is watched
+  watch:
+    apiVersion: dao.mayadata.io/v1alpha1
+    resource: cstorpoolcapacityrecommendations
+  # following resources are either read or applied:
+  #
+  # - HTTPData (read)
+  # - HTTP (applied)
+  attachments:
+  - apiVersion: dao.mayadata.io/v1alpha1
+    resource: httpdatas
+    advancedSelector:
+      selectorTerms:
+      - matchReferenceExpressions:
+        # select HTTPData resources if its name
+        # matches CStorPoolCapacityRecommendation _(read watch)_
+        # spec.httpDataName
+        - key: metadata.name
+          refKey: spec.httpDataName
+  - apiVersion: dao.mayadata.io/v1alpha1
+    resource: https
+    advancedSelector:
+      selectorTerms:
+      - matchReferenceExpressions:
+        # select HTTP resources if its annotation
+        # cspc-capacity-recommend.dao.mayadata.io/uid
+        # matches CStorPoolCapacityRecommendation _(read watch)_ UID
+        - key: metadata.annotations.cspc-capacity-recommend\.dao\.mayadata\.io/uid
+          refKey: metadata.uid
+  hooks:
+    sync:
+      inline:
+        funcName: sync/cspcaprecommendation
+---
+apiVersion: metac.openebs.io/v1alpha1
+kind: GenericController
+metadata:
+  # namespace & name combination should be unique
+  # across all the GenericControllers in this file
+  name: sync-cstorpoolauto
+  namespace: dope
+spec:
+  # resource with kind CStorPoolAuto is watched
+  watch:
+    apiVersion: dao.mayadata.io/v1alpha1
+    resource: cstorpoolautos
+  # following resources are either read or applied:
+  #
+  # - StatefulSet (read)
+  # - CustomResourceDefinition (applied)
+  attachments:
+  - apiVersion: apps/v1
+    resource: statefulsets
+    advancedSelector:
+      selectorTerms:
+      - matchReferenceExpressions:
+        # select StatefulSet resources if its annotation
+        # cstorpoolauto.dao.mayadata.io/uid matches
+        # CStorPoolAuto's _(read watch)_ UID
+        - key: metadata.annotations.cstorpoolauto\.dao\.mayadata\.io/uid
+          refKey: metadata.uid
+  - apiVersion: apiextensions.k8s.io/v1beta1
+    resource: customresourcedefinitions
+    advancedSelector:
+      selectorTerms:
+      - matchReferenceExpressions:
+        # select CustomResourceDefinitions if its annotation
+        # cstorpoolauto.dao.mayadata.io/uid matches
+        # CStorPoolAuto's _(read watch)_ UID
+        - key: metadata.annotations.cstorpoolauto\.dao\.mayadata\.io/uid
+          refKey: metadata.uid
+  - apiVersion: v1
+    resource: serviceaccounts
+    advancedSelector:
+      selectorTerms:
+      - matchReferenceExpressions:
+        # select ServiceAccount resources if its annotation
+        # cstorpoolauto.dao.mayadata.io/uid matches
+        # CStorPoolAuto's _(read watch)_ UID
+        - key: metadata.annotations.cstorpoolauto\.dao\.mayadata\.io/uid
+          refKey: metadata.uid
+  - apiVersion: rbac.authorization.k8s.io/v1
+    resource: clusterroles
+    advancedSelector:
+      selectorTerms:
+      - matchReferenceExpressions:
+        # select ClusterRole resources if its annotation
+        # cstorpoolauto.dao.mayadata.io/uid matches
+        # CStorPoolAuto's _(read watch)_ UID
+        - key: metadata.annotations.cstorpoolauto\.dao\.mayadata\.io/uid
+          refKey: metadata.uid
+  - apiVersion: rbac.authorization.k8s.io/v1
+    resource: clusterrolebindings
+    advancedSelector:
+      selectorTerms:
+      - matchReferenceExpressions:
+        # select ClusterRoleBinding resources if its annotation
+        # cstorpoolauto.dao.mayadata.io/uid matches
+        # CStorPoolAuto's _(read watch)_ UID
+        - key: metadata.annotations.cstorpoolauto\.dao\.mayadata\.io/uid
+          refKey: metadata.uid
+  hooks:
+    sync:
+      inline:
+        funcName: sync/cstorpoolauto
+---
+apiVersion: metac.openebs.io/v1alpha1
+kind: GenericController
+metadata:
+  # namespace & name combination should be unique
+  # across all the GenericControllers in this file
+  name: sync-doperator
+  namespace: dope
+spec:
+  # resource with kind CStorPoolAuto is watched
+  watch:
+    apiVersion: dao.mayadata.io/v1alpha1
+    resource: doperators
+  # following resources are either read or applied:
+  #
+  # - StatefulSet (read)
+  # - CustomResourceDefinition (applied)
+  attachments:
+  - apiVersion: apiextensions.k8s.io/v1beta1
+    resource: customresourcedefinitions
+    advancedSelector:
+      selectorTerms:
+      - matchReferenceExpressions:
+        # select CustomResourceDefinitions if its annotation
+        # cstorpoolauto.dao.mayadata.io/uid matches
+        # DOperator's _(read watch)_ UID
+        - key: metadata.annotations.doperator\.dao\.mayadata\.io/uid
+          refKey: metadata.uid
+  hooks:
+    sync:
+      inline:
+        funcName: sync/doperator

--- a/controller/cstorpoolauto/reconciler.go
+++ b/controller/cstorpoolauto/reconciler.go
@@ -15,3 +15,530 @@ limitations under the License.
 */
 
 package cstorpoolauto
+
+import (
+	"fmt"
+
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"openebs.io/metac/controller/generic"
+
+	ctrlutil "mayadata.io/d-operators/common/controller"
+	"mayadata.io/d-operators/common/unstruct"
+	types "mayadata.io/d-operators/types/cstorpoolauto"
+)
+
+// Reconciler manages CStorPoolAuto operational needs
+// by reconciling CStorPoolAuto custom resource
+type Reconciler struct {
+	ctrlutil.Reconciler
+
+	observedCStorPoolAuto *types.CStorPoolAuto
+
+	desiredLogLevel string
+}
+
+func (r *Reconciler) walkAndSetObservedCStorPoolAuto() {
+	var cspauto types.CStorPoolAuto
+	err := unstruct.ToTyped(
+		r.HookRequest.Watch,
+		&cspauto,
+	)
+	if err != nil {
+		r.Err = err
+		return
+	}
+	// set observed watch
+	r.observedCStorPoolAuto = &cspauto
+	// set the desired log level
+	if cspauto.Spec.LogLevel == nil {
+		r.desiredLogLevel = fmt.Sprintf("%d", 1)
+	} else {
+		r.desiredLogLevel = fmt.Sprintf("%d", *cspauto.Spec.LogLevel)
+	}
+}
+
+func (r *Reconciler) setDesiredCRDCStorClusterConfig() {
+	crd := &unstructured.Unstructured{
+		Object: map[string]interface{}{
+			"apiVersion": "apiextensions.k8s.io/v1beta1",
+			"kind":       "CustomResourceDefinition",
+			"metadata": map[string]interface{}{
+				"name": "cstorclusterconfigs.dao.mayadata.io",
+				"annotations": map[string]interface{}{
+					// refer to the watch that triggered this
+					"cstorpoolauto.dao.mayadata.io/uid": r.observedCStorPoolAuto.UID,
+				},
+			},
+			"spec": map[string]interface{}{
+				"group":   "dao.mayadata.io",
+				"version": "v1alpha1",
+				"scope":   "Namespaced",
+				"names": map[string]interface{}{
+					"plural":   "cstorclusterconfigs",
+					"singular": "cstorclusterconfig",
+					"kind":     "CStorClusterConfig",
+					"shortNames": []interface{}{
+						"cscconfig",
+					},
+				},
+			},
+		},
+	}
+	r.HookResponse.Attachments = append(
+		r.HookResponse.Attachments,
+		crd,
+	)
+}
+
+func (r *Reconciler) setDesiredCRDCStorClusterPlan() {
+	crd := &unstructured.Unstructured{
+		Object: map[string]interface{}{
+			"apiVersion": "apiextensions.k8s.io/v1beta1",
+			"kind":       "CustomResourceDefinition",
+			"metadata": map[string]interface{}{
+				"name": "cstorclusterplans.dao.mayadata.io",
+				"annotations": map[string]interface{}{
+					// refer to the watch that triggered this
+					"cstorpoolauto.dao.mayadata.io/uid": r.observedCStorPoolAuto.UID,
+				},
+			},
+			"spec": map[string]interface{}{
+				"group":   "dao.mayadata.io",
+				"version": "v1alpha1",
+				"scope":   "Namespaced",
+				"names": map[string]interface{}{
+					"plural":   "cstorclusterplans",
+					"singular": "cstorclusterplan",
+					"kind":     "CStorClusterPlan",
+					"shortNames": []interface{}{
+						"cscplan",
+					},
+				},
+			},
+		},
+	}
+	r.HookResponse.Attachments = append(
+		r.HookResponse.Attachments,
+		crd,
+	)
+}
+
+func (r *Reconciler) setDesiredCRDCStorClusterStorageSet() {
+	crd := &unstructured.Unstructured{
+		Object: map[string]interface{}{
+			"apiVersion": "apiextensions.k8s.io/v1beta1",
+			"kind":       "CustomResourceDefinition",
+			"metadata": map[string]interface{}{
+				"name": "cstorclusterstoragesets.dao.mayadata.io",
+				"annotations": map[string]interface{}{
+					// refer to the watch that triggered this
+					"cstorpoolauto.dao.mayadata.io/uid": r.observedCStorPoolAuto.UID,
+				},
+			},
+			"spec": map[string]interface{}{
+				"group":   "dao.mayadata.io",
+				"version": "v1alpha1",
+				"scope":   "Namespaced",
+				"names": map[string]interface{}{
+					"plural":   "cstorclusterstoragesets",
+					"singular": "cstorclusterstorageset",
+					"kind":     "CStorClusterStorageSet",
+					"shortNames": []interface{}{
+						"cscstorageset",
+					},
+				},
+			},
+		},
+	}
+	r.HookResponse.Attachments = append(
+		r.HookResponse.Attachments,
+		crd,
+	)
+}
+
+func (r *Reconciler) setDesiredCRDStorage() {
+	crd := &unstructured.Unstructured{
+		Object: map[string]interface{}{
+			"apiVersion": "apiextensions.k8s.io/v1beta1",
+			"kind":       "CustomResourceDefinition",
+			"metadata": map[string]interface{}{
+				"name": "storages.dao.mayadata.io",
+				"annotations": map[string]interface{}{
+					// refer to the watch that triggered this
+					"cstorpoolauto.dao.mayadata.io/uid": r.observedCStorPoolAuto.UID,
+				},
+			},
+			"spec": map[string]interface{}{
+				"group":   "dao.mayadata.io",
+				"version": "v1alpha1",
+				"scope":   "Namespaced",
+				"names": map[string]interface{}{
+					"plural":   "storages",
+					"singular": "storage",
+					"kind":     "Storage",
+					"shortNames": []interface{}{
+						"stor",
+					},
+				},
+				"additionalPrinterColumns": []interface{}{
+					map[string]interface{}{
+						"JSONPath":    ".spec.capacity",
+						"name":        "Capacity",
+						"description": "Capacity of storage",
+						"type":        "string",
+					},
+					map[string]interface{}{
+						"JSONPath":    ".spec.nodeName",
+						"name":        "NodeName",
+						"description": "Node where storage gets attached",
+						"type":        "string",
+					},
+					map[string]interface{}{
+						"JSONPath":    ".status.phase",
+						"name":        "Status",
+						"description": "Identifies the current status of storage",
+						"type":        "string",
+					},
+				},
+			},
+		},
+	}
+	r.HookResponse.Attachments = append(
+		r.HookResponse.Attachments,
+		crd,
+	)
+}
+
+func (r *Reconciler) setDesiredCRDs() {
+	if r.observedCStorPoolAuto.Spec.InstallCRD != nil &&
+		!*r.observedCStorPoolAuto.Spec.InstallCRD {
+		return
+	}
+	r.setDesiredCRDStorage()
+	r.setDesiredCRDCStorClusterConfig()
+	r.setDesiredCRDCStorClusterPlan()
+	r.setDesiredCRDCStorClusterStorageSet()
+}
+
+func (r *Reconciler) setDesiredServiceAccount() {
+	sa := &unstructured.Unstructured{
+		Object: map[string]interface{}{
+			"apiVersion": "v1",
+			"kind":       "ServiceAccount",
+			"metadata": map[string]interface{}{
+				"name":      r.observedCStorPoolAuto.Spec.ServiceAccountName,
+				"namespace": r.observedCStorPoolAuto.Spec.TargetNamespace,
+				"annotations": map[string]interface{}{
+					// refer to the watch that triggered this
+					"cstorpoolauto.dao.mayadata.io/uid": r.observedCStorPoolAuto.UID,
+				},
+			},
+		},
+	}
+	r.HookResponse.Attachments = append(
+		r.HookResponse.Attachments,
+		sa,
+	)
+}
+
+func (r *Reconciler) setDesiredClusterRole() {
+	crole := &unstructured.Unstructured{
+		Object: map[string]interface{}{
+			"apiVersion": "rbac.authorization.k8s.io/v1",
+			"kind":       "ClusterRole",
+			"metadata": map[string]interface{}{
+				"name": r.observedCStorPoolAuto.Spec.ServiceAccountName,
+				"annotations": map[string]interface{}{
+					// refer to the watch that triggered this
+					"cstorpoolauto.dao.mayadata.io/uid": r.observedCStorPoolAuto.UID,
+				},
+			},
+			"rules": []interface{}{
+				map[string]interface{}{
+					"apiGroups": []interface{}{
+						"openebs.io",
+					},
+					"resources": []interface{}{
+						"blockdevices",
+					},
+					"verbs": []interface{}{
+						"get",
+						"list",
+						"watch",
+						"update",
+					},
+				},
+				map[string]interface{}{
+					"apiGroups": []interface{}{
+						"",
+					},
+					"resources": []interface{}{
+						"persistentvolumeclaims",
+					},
+					"verbs": []interface{}{
+						"get",
+						"list",
+						"watch",
+						"create",
+						"update",
+					},
+				},
+				map[string]interface{}{
+					"apiGroups": []interface{}{
+						"",
+					},
+					"resources": []interface{}{
+						"customresourcedefinitions",
+					},
+					"verbs": []interface{}{
+						"get",
+						"list",
+						"create",
+						"update",
+					},
+				},
+				map[string]interface{}{
+					"apiGroups": []interface{}{
+						"",
+					},
+					"resources": []interface{}{
+						"nodes",
+					},
+					"verbs": []interface{}{
+						"get",
+						"list",
+					},
+				},
+				map[string]interface{}{
+					"apiGroups": []interface{}{
+						"storage.k8s.io",
+					},
+					"resources": []interface{}{
+						"volumeattachments",
+					},
+					"verbs": []interface{}{
+						"get",
+						"list",
+						"watch",
+						"create",
+						"update",
+					},
+				},
+				map[string]interface{}{
+					"apiGroups": []interface{}{
+						"dao.mayadata.io",
+					},
+					"resources": []interface{}{
+						"storages",
+						"cstorclusterconfigs",
+						"cstorclusterplans",
+						"cstorclusterstoragesets",
+						"cstorpoolclusters",
+					},
+					"verbs": []interface{}{
+						"get",
+						"list",
+						"watch",
+						"create",
+						"update",
+					},
+				},
+			},
+		},
+	}
+	r.HookResponse.Attachments = append(
+		r.HookResponse.Attachments,
+		crole,
+	)
+}
+
+func (r *Reconciler) setDesiredClusterRoleBinding() {
+	crb := &unstructured.Unstructured{
+		Object: map[string]interface{}{
+			"apiVersion": "rbac.authorization.k8s.io/v1",
+			"kind":       "ClusterRoleBinding",
+			"metadata": map[string]interface{}{
+				"name": r.observedCStorPoolAuto.Spec.ServiceAccountName,
+				"annotations": map[string]interface{}{
+					// refer to the watch that triggered this
+					"cstorpoolauto.dao.mayadata.io/uid": r.observedCStorPoolAuto.UID,
+				},
+			},
+			"subjects": []interface{}{
+				map[string]interface{}{
+					"kind":      "ServiceAccount",
+					"name":      r.observedCStorPoolAuto.Spec.ServiceAccountName,
+					"namespace": r.observedCStorPoolAuto.Spec.TargetNamespace,
+				},
+			},
+			"roleRef": map[string]interface{}{
+				"kind":     "ClusterRole",
+				"name":     r.observedCStorPoolAuto.Spec.ServiceAccountName,
+				"apiGroup": "rbac.authorization.k8s.io",
+			},
+		},
+	}
+	r.HookResponse.Attachments = append(
+		r.HookResponse.Attachments,
+		crb,
+	)
+}
+
+func (r *Reconciler) setDesiredRBAC() {
+	if r.observedCStorPoolAuto.Spec.InstallRBAC != nil &&
+		!*r.observedCStorPoolAuto.Spec.InstallRBAC {
+		return
+	}
+	r.setDesiredServiceAccount()
+	r.setDesiredClusterRole()
+	r.setDesiredClusterRoleBinding()
+}
+
+func (r *Reconciler) setDesiredStorageProvisionerSTS() {
+	cspauto := r.observedCStorPoolAuto
+	sts := &unstructured.Unstructured{
+		Object: map[string]interface{}{
+			"apiVersion": "apps/v1",
+			"kind":       "StatefulSet",
+			"metadata": map[string]interface{}{
+				"name":      "storage-provisioner",
+				"namespace": cspauto.Spec.TargetNamespace,
+				"labels": map[string]interface{}{
+					"app.mayadata.io/name": "storage-provisioner",
+				},
+				"annotations": map[string]interface{}{
+					// refer to the watch that triggered this
+					"cstorpoolauto.dao.mayadata.io/uid": cspauto.UID,
+				},
+			},
+			"spec": map[string]interface{}{
+				"replicas": 1,
+				"selector": map[string]interface{}{
+					"matchLabels": map[string]interface{}{
+						"app.mayadata.io/name": "storage-provisioner",
+					},
+				},
+				"template": map[string]interface{}{
+					"metadata": map[string]interface{}{
+						"labels": map[string]interface{}{
+							"app.mayadata.io/name": "storage-provisioner",
+						},
+					},
+					"spec": map[string]interface{}{
+						"serviceAccountName": cspauto.Spec.ServiceAccountName,
+						"containers": []interface{}{
+							map[string]interface{}{
+								"name":  "storage-provisioner",
+								"image": cspauto.Spec.StorageProvisionerImage,
+								"args": []interface{}{
+									"--v=" + r.desiredLogLevel,
+								},
+								"env": []interface{}{
+									map[string]interface{}{
+										"name": "MY_NAME",
+										"valueFrom": map[string]interface{}{
+											"fieldRef": map[string]interface{}{
+												"fieldPath": "metadata.name",
+											},
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+	r.HookResponse.Attachments = append(
+		r.HookResponse.Attachments,
+		sts,
+	)
+}
+
+func (r *Reconciler) setDesiredCStorPoolAutoSTS() {
+	cspauto := r.observedCStorPoolAuto
+	sts := &unstructured.Unstructured{
+		Object: map[string]interface{}{
+			"apiVersion": "apps/v1",
+			"kind":       "StatefulSet",
+			"metadata": map[string]interface{}{
+				"name":      "cstorpoolauto",
+				"namespace": cspauto.Spec.TargetNamespace,
+				"labels": map[string]interface{}{
+					"app.mayadata.io/name": "cstorpoolauto",
+				},
+				"annotations": map[string]interface{}{
+					// refer to the watch that triggered this
+					"cstorpoolauto.dao.mayadata.io/uid": cspauto.UID,
+				},
+			},
+			"spec": map[string]interface{}{
+				"replicas": 1,
+				"selector": map[string]interface{}{
+					"matchLabels": map[string]interface{}{
+						"app.mayadata.io/name": "cstorpoolauto",
+					},
+				},
+				"template": map[string]interface{}{
+					"metadata": map[string]interface{}{
+						"labels": map[string]interface{}{
+							"app.mayadata.io/name": "cstorpoolauto",
+						},
+					},
+					"spec": map[string]interface{}{
+						"serviceAccountName": cspauto.Spec.ServiceAccountName,
+						"containers": []interface{}{
+							map[string]interface{}{
+								"name":  "cstorpoolauto",
+								"image": cspauto.Spec.CStorPoolAutoImage,
+								"command": []interface{}{
+									"/usr/bin/cstorpoolauto",
+								},
+								"args": []interface{}{
+									"--logtostderr",
+									"--run-as-local",
+									"-v=" + r.desiredLogLevel,
+									"--discovery-interval=40s",
+									"--cache-flush-interval=240s",
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+	r.HookResponse.Attachments = append(
+		r.HookResponse.Attachments,
+		sts,
+	)
+}
+
+// Sync implements the idempotent logic to sync HTTP
+//
+// NOTE:
+// 	SyncHookRequest is the payload received as part of reconcile
+// request. Similarly, SyncHookResponse is the payload sent as a
+// response as part of reconcile request.
+//
+// NOTE:
+//	This controller watches CStorPoolAuto custom resource
+func Sync(request *generic.SyncHookRequest, response *generic.SyncHookResponse) error {
+	r := &Reconciler{}
+	r.HookRequest = request
+	r.HookResponse = response
+
+	// add functions to achieve desired state
+	r.ReconcileFns = []func(){
+		r.setDesiredRBAC,
+		r.setDesiredCRDs,
+		r.setDesiredStorageProvisionerSTS,
+		r.setDesiredCStorPoolAutoSTS,
+	}
+
+	// add functions to achieve desired watch
+	r.DesiredWatchFns = []func(){}
+	// run reconcile
+	return r.Reconcile()
+}

--- a/controller/director/http/add_get_active_nodes.go
+++ b/controller/director/http/add_get_active_nodes.go
@@ -1,0 +1,61 @@
+/*
+Copyright 2020 The MayaData Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    https://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package http
+
+import (
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	types "mayadata.io/d-operators/types/director"
+	"mayadata.io/d-operators/types/gvk"
+	http "mayadata.io/d-operators/types/http"
+)
+
+func (r *Reconciler) addGetActiveNodes() {
+	if !r.observedIncludes.ContainsExact(types.IncludeAllAPIs) &&
+		!r.observedIncludes.ContainsExact(types.GetActiveNodes) {
+		// nothing to be done since this is not included
+		// as part of DIrectorHTTP
+		return
+	}
+	var headers, pathParams map[string]string
+	if r.observedHTTPData != nil {
+		headers = r.observedHTTPData.Spec.Headers
+		pathParams = r.observedHTTPData.Spec.PathParams
+	}
+	r.desiredStates = append(
+		r.desiredStates,
+		&unstructured.Unstructured{
+			Object: map[string]interface{}{
+				"kind":       gvk.KindHTTP,
+				"apiVersion": gvk.VersionV1Alpha1,
+				"metadata": map[string]interface{}{
+					"name":      types.GetActiveNodes,
+					"namespace": r.observedDirectorNamespace,
+					"annotations": map[string]interface{}{
+						"directorhttp.dao.mayadata.io/uid": r.observedDirector.GetUID(),
+					},
+				},
+				"spec": map[string]interface{}{
+					"secretName": r.observedSecretName,
+					"headers":    headers,
+					"pathParams": pathParams,
+					"url":        types.URLActiveNodes,
+					"method":     http.GET,
+				},
+			},
+		},
+	)
+}

--- a/controller/director/http/registrar.go
+++ b/controller/director/http/registrar.go
@@ -20,7 +20,8 @@ func (r *Reconciler) registerAPIs() {
 	r.registeredAPIs = append(
 		r.registeredAPIs,
 		// NOTE:
-		//   Add all the director APIs here
-		r.addAPIForActiveNodesOrNone,
+		//   Add the registered/supported director APIs here
+		r.addGetActiveNodes,
+		r.addGetProjectDetails,
 	)
 }

--- a/controller/director/recommendations/cstorpool/capacity/reconciler.go
+++ b/controller/director/recommendations/cstorpool/capacity/reconciler.go
@@ -1,0 +1,413 @@
+/*
+Copyright 2020 The MayaData Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    https://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package capacity
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/pkg/errors"
+	"github.com/tidwall/gjson"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/util/json"
+	"openebs.io/metac/controller/generic"
+
+	ctrlutil "mayadata.io/d-operators/common/controller"
+	"mayadata.io/d-operators/common/unstruct"
+	types "mayadata.io/d-operators/types/director"
+	"mayadata.io/d-operators/types/gvk"
+	http "mayadata.io/d-operators/types/http"
+)
+
+// Reconciler manages reconciliation of HTTP resources
+type Reconciler struct {
+	ctrlutil.Reconciler
+
+	observedCSPCapRecommend    *types.CStorPoolCapacityRecommendation
+	observedHTTPDataName       string
+	observedHTTPData           *http.HTTPData
+	observedSecretName         string
+	observedClusterID          string
+	observedRAIDDeviceCount    int
+	observedRAIDType           string
+	observedRecommendationList *http.HTTP
+	observedPathParams         map[string]string
+
+	desiredRecommendationListName                 string
+	desiredCSPCapRecommendationName               string
+	desiredRecommendationID                       string
+	desiredCSPCapacityRecommendationBody          string
+	desiredPathParamsForCSPCapacityRecommendation map[string]string
+}
+
+func (r *Reconciler) walkObservedCSPCapacityRecommendation() {
+	var recommend types.CStorPoolCapacityRecommendation
+	err := unstruct.ToTyped(
+		r.HookRequest.Watch,
+		&recommend,
+	)
+	if err != nil {
+		r.Err = err
+		return
+	}
+	r.observedCSPCapRecommend = &recommend
+	// set httpdata name
+	r.observedHTTPDataName = recommend.Spec.HTTPDataName
+	if r.observedHTTPDataName == "" {
+		r.Err = errors.Errorf("Missing spec.httpDataName")
+	}
+	// set secret name
+	r.observedSecretName = recommend.Spec.SecretName
+	if r.observedSecretName == "" {
+		r.Err = errors.Errorf("Missing spec.secretName")
+		return
+	}
+	// set device count
+	r.observedRAIDDeviceCount = recommend.Spec.RAIDDeviceCount
+	if r.observedRAIDDeviceCount == 0 {
+		r.Err = errors.Errorf("Missing / Invalid spec.raidDeviceCount")
+		return
+	}
+	// set raid type
+	r.observedRAIDType = recommend.Spec.RAIDType
+	if r.observedRAIDType == "" {
+		r.Err = errors.Errorf("Missing spec.raidType")
+		return
+	}
+	// set desired recommendation list name
+	r.desiredRecommendationListName =
+		recommend.GetName() + "-recommend-list"
+	// set desired csp capacity recommendation name
+	r.desiredCSPCapRecommendationName =
+		recommend.GetName() + "-csp-capacity-recommend"
+}
+
+func (r *Reconciler) walkObservedHTTPData() {
+	var httpdata http.HTTPData
+	obj := r.HookRequest.Attachments.FindByGroupKindName(
+		gvk.GroupDAOMayadataIO,
+		gvk.KindHTTPData,
+		r.observedHTTPDataName,
+	)
+	if obj == nil {
+		r.Err = errors.Errorf(
+			"HTTPData %q not found",
+			r.observedHTTPDataName,
+		)
+		return
+	}
+	// add it back to response attachments
+	//
+	// NOTE:
+	//	Adding back the request attachments to response
+	// attachments help in evaluating the completion state
+	r.HookResponse.Attachments = append(
+		r.HookResponse.Attachments,
+		obj,
+	)
+	// extract path params from HTTPData
+	err := unstruct.ToTyped(
+		obj,
+		&httpdata,
+	)
+	if err != nil {
+		r.Err = err
+		return
+	}
+	r.observedHTTPData = &httpdata
+	// extract cluster id from HTTPData
+	r.observedPathParams = r.observedHTTPData.Spec.PathParams
+	if len(r.observedPathParams) == 0 {
+		r.Err = errors.Errorf(
+			"Missing spec.pathParams in %q / %q: %s",
+			r.observedHTTPData.GetNamespace(),
+			r.observedHTTPData.GetName(),
+			r.observedHTTPData.GetObjectKind().GroupVersionKind().String(),
+		)
+		return
+	}
+	r.observedClusterID = r.observedPathParams["clusterId"]
+	// this is used in the body of some requests
+	if r.observedClusterID == "" {
+		r.Err = errors.Errorf(
+			"Missing spec.pathParams.clusterId in %q / %q: %s",
+			r.observedHTTPData.GetNamespace(),
+			r.observedHTTPData.GetName(),
+			r.observedHTTPData.GetObjectKind().GroupVersionKind().String(),
+		)
+		return
+	}
+}
+
+func (r *Reconciler) walkObservedRecommendationList() {
+	var observedRecommendationList http.HTTP
+	obj := r.HookRequest.Attachments.FindByGroupKindName(
+		gvk.GroupDAOMayadataIO,
+		gvk.KindHTTP,
+		r.desiredRecommendationListName,
+	)
+	if obj == nil {
+		// reconciliation has not yet happened
+		r.Warns = append(
+			r.Warns,
+			"No recommendation list observed",
+		)
+		return
+	}
+	err := unstruct.ToTyped(
+		obj,
+		&observedRecommendationList,
+	)
+	if err != nil {
+		r.Err = errors.Wrapf(
+			err,
+			"Failed to convert recommendation list to typed",
+		)
+		return
+	}
+	r.observedRecommendationList = &observedRecommendationList
+}
+
+func (r *Reconciler) setDesiredRecommendationIDForCStorPool() {
+	if r.observedRecommendationList == nil {
+		// nothing to do
+		return
+	}
+	rList := r.observedRecommendationList
+	var isComplete = "false"
+	if rList.Status.Completion != nil {
+		isComplete = fmt.Sprintf(
+			"%v",
+			rList.Status.Completion["state"],
+		)
+	}
+	// extract current phase
+	phase := rList.Status.Phase
+	if isComplete == "false" || phase == "" || phase == http.HTTPStatusPhaseError {
+		r.Warns = append(
+			r.Warns,
+			"Yet to receive recommendation list response: IsComplete=%t: Phase=%q",
+			isComplete,
+			phase,
+		)
+		return
+	}
+	// extract the http response of recommendation list API
+	recommendations, err := json.Marshal(rList.Status.Body)
+	if err != nil {
+		r.Err = errors.Wrapf(
+			err,
+			"Failed to marshal status.body of %q / %q: %s",
+			rList.GetNamespace(),
+			rList.GetName(),
+			rList.GetObjectKind().GroupVersionKind().String(),
+		)
+		return
+	}
+	// extract recommendation id relevant to cStorPool
+	r.desiredRecommendationID = gjson.Get(
+		string(recommendations),
+		`data.#(name=="cStorPool").id`,
+	).String()
+	// verify if it was found
+	if r.desiredRecommendationID == "" {
+		r.Err = errors.Wrapf(
+			err,
+			"Missing recommendation id for cStorPool in %q / %q: %s",
+			rList.GetNamespace(),
+			rList.GetName(),
+			rList.GetObjectKind().GroupVersionKind().String(),
+		)
+		return
+	}
+}
+
+func (r *Reconciler) setDesiredPathParamsForCSPCapRecommendation() {
+	if r.desiredRecommendationID == "" {
+		return
+	}
+	r.desiredPathParamsForCSPCapacityRecommendation = map[string]string{
+		"recommendation_csp_id": r.desiredRecommendationID,
+	}
+	for k, v := range r.observedPathParams {
+		r.desiredPathParamsForCSPCapacityRecommendation[k] = v
+	}
+}
+
+func (r *Reconciler) setDesiredRecommendationList() {
+	cspcCapRecommend := r.observedCSPCapRecommend
+	obj := &unstructured.Unstructured{
+		Object: map[string]interface{}{
+			"apiVersion": gvk.DAOMayadataIOV1Alpha1,
+			"kind":       gvk.KindHTTP,
+			"metadata": map[string]interface{}{
+				"name":      r.desiredRecommendationListName,
+				"namespace": cspcCapRecommend.GetNamespace(),
+				"annotations": map[string]interface{}{
+					// mention the resource that created this
+					"cspc-capacity-recommend.dao.mayadata.io/uid": cspcCapRecommend.GetUID(),
+				},
+			},
+			"spec": map[string]interface{}{
+				"secretName": r.observedSecretName,
+				"url":        types.URLRecommendationList,
+				"pathParams": r.observedPathParams,
+				"method":     http.GET,
+			},
+		},
+	}
+	r.HookResponse.Attachments = append(
+		r.HookResponse.Attachments,
+		obj,
+	)
+}
+
+func (r *Reconciler) buildDesiredCSPCapacityRecommendationBody() {
+	if r.desiredRecommendationID == "" {
+		// yet to receive list of recommendations
+		return
+	}
+	body := map[string]interface{}{
+		"clusterId": r.observedClusterID,
+		"raidGroupConfig": map[string]interface{}{
+			"groupDeviceCount": r.observedRAIDDeviceCount,
+			"type":             r.observedRAIDType,
+		},
+	}
+	bodyBytes, err := json.Marshal(body)
+	if err != nil {
+		r.Err = errors.Wrapf(
+			err,
+			"Failed to build capacity based cstor pool recommendation",
+		)
+		return
+	}
+	r.desiredCSPCapacityRecommendationBody = string(bodyBytes)
+}
+
+func (r *Reconciler) setDesiredCSPCapacityRecommendation() {
+	if r.desiredRecommendationID == "" {
+		// yet to receive list of recommendations
+		return
+	}
+	cspcCapRecommend := r.observedCSPCapRecommend
+	obj := &unstructured.Unstructured{
+		Object: map[string]interface{}{
+			"apiVersion": gvk.DAOMayadataIOV1Alpha1,
+			"kind":       gvk.KindHTTP,
+			"metadata": map[string]interface{}{
+				"name":      r.desiredCSPCapRecommendationName,
+				"namespace": cspcCapRecommend.GetNamespace(),
+				"annotations": map[string]interface{}{
+					// mention the resource that created this
+					"cspc-capacity-recommend.dao.mayadata.io/uid": cspcCapRecommend.GetUID(),
+				},
+			},
+			"spec": map[string]interface{}{
+				"secretName": r.observedSecretName,
+				"url":        types.URLGetCSPCapacityRecommendation,
+				"pathParams": r.desiredPathParamsForCSPCapacityRecommendation,
+				"method":     http.POST,
+				"body":       r.desiredCSPCapacityRecommendationBody,
+			},
+		},
+	}
+	r.HookResponse.Attachments = append(
+		r.HookResponse.Attachments,
+		obj,
+	)
+}
+
+func (r *Reconciler) updateWatchStatus() {
+	var status = map[string]interface{}{}
+	var completion = map[string]interface{}{
+		"state": false,
+	}
+	var warn string
+	// init with Online
+	status["phase"] = types.HTTPStatusOnline
+	// check for warnings
+	if len(r.Warns) != 0 {
+		warn = fmt.Sprintf(
+			"%d warnings: %s",
+			len(r.Warns),
+			strings.Join(r.Warns, ": "),
+		)
+	}
+	if warn != "" {
+		status["warn"] = warn
+	}
+	// is runtime error
+	if r.Err != nil {
+		status["phase"] = types.HTTPStatusError
+		status["reason"] = r.Err.Error()
+	}
+	// hook request has the observed state of children
+	observedAttachments := r.HookRequest.Attachments.Len()
+	// hook response has the desired state of children
+	desiredAttachments := len(r.HookResponse.Attachments)
+	// we expect 3 attachments in response:
+	//
+	// - HTTPData
+	// - HTTP for RecommendationList
+	// - HTTP for CStorPool Capacity Recommendation
+	if r.Err == nil && desiredAttachments == 3 {
+		completion["state"] = true
+	}
+	completion["observedAttachmentCount"] = observedAttachments
+	completion["desiredAttachmentCount"] = desiredAttachments
+	// set completion status
+	status["completion"] = completion
+	// set the desired status against hook response
+	r.HookResponse.Status = status
+}
+
+// Sync implements the idempotent logic to sync DirectorHTTP
+//
+// NOTE:
+// 	SyncHookRequest is the payload received as part of reconcile
+// request. Similarly, SyncHookResponse is the payload sent as a
+// response as part of reconcile request.
+//
+// NOTE:
+//	This controller watches CStorPoolCapacityRecommendation custom
+// resource
+func Sync(request *generic.SyncHookRequest, response *generic.SyncHookResponse) error {
+	r := &Reconciler{}
+	r.HookRequest = request
+	r.HookResponse = response
+
+	// add logic to achieve desired state of attachments/children
+	r.ReconcileFns = []func(){
+		r.walkObservedCSPCapacityRecommendation,
+		r.walkObservedHTTPData,
+		r.walkObservedRecommendationList,
+		r.setDesiredRecommendationList,
+		r.setDesiredRecommendationIDForCStorPool,
+		r.setDesiredPathParamsForCSPCapRecommendation,
+		r.buildDesiredCSPCapacityRecommendationBody,
+		r.setDesiredCSPCapacityRecommendation,
+	}
+
+	// add logic to achieve desired state of watch
+	r.DesiredWatchFns = []func(){
+		r.updateWatchStatus,
+	}
+
+	// run reconcile
+	return r.Reconcile()
+}

--- a/controller/doperator/reconciler.go
+++ b/controller/doperator/reconciler.go
@@ -15,3 +15,265 @@ limitations under the License.
 */
 
 package doperator
+
+import (
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"openebs.io/metac/controller/generic"
+
+	ctrlutil "mayadata.io/d-operators/common/controller"
+	"mayadata.io/d-operators/common/unstruct"
+	types "mayadata.io/d-operators/types/doperator"
+)
+
+// Reconciler manages CStorPoolAuto operational needs
+// by reconciling CStorPoolAuto custom resource
+type Reconciler struct {
+	ctrlutil.Reconciler
+
+	observedDOperator *types.DOperator
+}
+
+func (r *Reconciler) walkObservedDOperator() {
+	var dope types.DOperator
+	err := unstruct.ToTyped(
+		r.HookRequest.Watch,
+		&dope,
+	)
+	if err != nil {
+		r.Err = err
+		return
+	}
+	// set observed watch
+	r.observedDOperator = &dope
+}
+
+func (r *Reconciler) setDesiredCRDBlockDeviceSet() {
+	crd := &unstructured.Unstructured{
+		Object: map[string]interface{}{
+			"apiVersion": "apiextensions.k8s.io/v1beta1",
+			"kind":       "CustomResourceDefinition",
+			"metadata": map[string]interface{}{
+				"name": "blockdevicesets.dao.mayadata.io",
+				"annotations": map[string]interface{}{
+					// refer to the object that triggered this creation
+					"doperator.dao.mayadata.io/uid": r.observedDOperator.UID,
+				},
+			},
+			"spec": map[string]interface{}{
+				"group":   "dao.mayadata.io",
+				"version": "v1alpha1",
+				"scope":   "Namespaced",
+				"names": map[string]interface{}{
+					"plural":   "blockdevicesets",
+					"singular": "blockdeviceset",
+					"kind":     "BlockDeviceSet",
+					"shortNames": []interface{}{
+						"bdset",
+					},
+				},
+			},
+		},
+	}
+	r.HookResponse.Attachments = append(
+		r.HookResponse.Attachments,
+		crd,
+	)
+}
+
+func (r *Reconciler) setDesiredCRDHTTP() {
+	crd := &unstructured.Unstructured{
+		Object: map[string]interface{}{
+			"apiVersion": "apiextensions.k8s.io/v1beta1",
+			"kind":       "CustomResourceDefinition",
+			"metadata": map[string]interface{}{
+				"name": "https.dao.mayadata.io",
+				"annotations": map[string]interface{}{
+					// refer to the object that triggered this creation
+					"doperator.dao.mayadata.io/uid": r.observedDOperator.UID,
+				},
+			},
+			"spec": map[string]interface{}{
+				"group":   "dao.mayadata.io",
+				"version": "v1alpha1",
+				"scope":   "Namespaced",
+				"names": map[string]interface{}{
+					"plural":   "https",
+					"singular": "http",
+					"kind":     "HTTP",
+					"shortNames": []interface{}{
+						"http",
+					},
+				},
+			},
+		},
+	}
+	r.HookResponse.Attachments = append(
+		r.HookResponse.Attachments,
+		crd,
+	)
+}
+
+func (r *Reconciler) setDesiredCRDHTTPData() {
+	crd := &unstructured.Unstructured{
+		Object: map[string]interface{}{
+			"apiVersion": "apiextensions.k8s.io/v1beta1",
+			"kind":       "CustomResourceDefinition",
+			"metadata": map[string]interface{}{
+				"name": "httpdatas.dao.mayadata.io",
+				"annotations": map[string]interface{}{
+					// refer to the object that triggered this creation
+					"doperator.dao.mayadata.io/uid": r.observedDOperator.UID,
+				},
+			},
+			"spec": map[string]interface{}{
+				"group":   "dao.mayadata.io",
+				"version": "v1alpha1",
+				"scope":   "Namespaced",
+				"names": map[string]interface{}{
+					"plural":   "httpdatas",
+					"singular": "httpdata",
+					"kind":     "HTTPData",
+					"shortNames": []interface{}{
+						"httpdata",
+					},
+				},
+			},
+		},
+	}
+	r.HookResponse.Attachments = append(
+		r.HookResponse.Attachments,
+		crd,
+	)
+}
+
+func (r *Reconciler) setDesiredCRDCStorPoolCapacityRecommendation() {
+	crd := &unstructured.Unstructured{
+		Object: map[string]interface{}{
+			"apiVersion": "apiextensions.k8s.io/v1beta1",
+			"kind":       "CustomResourceDefinition",
+			"metadata": map[string]interface{}{
+				"name": "cstorpoolcapacityrecommendations.dao.mayadata.io",
+				"annotations": map[string]interface{}{
+					// refer to the object that triggered this creation
+					"doperator.dao.mayadata.io/uid": r.observedDOperator.UID,
+				},
+			},
+			"spec": map[string]interface{}{
+				"group":   "dao.mayadata.io",
+				"version": "v1alpha1",
+				"scope":   "Namespaced",
+				"names": map[string]interface{}{
+					"plural":   "cstorpoolcapacityrecommendations",
+					"singular": "cstorpoolcapacityrecommendation",
+					"kind":     "CStorPoolCapacityRecommendation",
+					"shortNames": []interface{}{
+						"cspcapr",
+					},
+				},
+			},
+		},
+	}
+	r.HookResponse.Attachments = append(
+		r.HookResponse.Attachments,
+		crd,
+	)
+}
+
+func (r *Reconciler) setDesiredCRDDirectorHTTP() {
+	crd := &unstructured.Unstructured{
+		Object: map[string]interface{}{
+			"apiVersion": "apiextensions.k8s.io/v1beta1",
+			"kind":       "CustomResourceDefinition",
+			"metadata": map[string]interface{}{
+				"name": "directorhttps.dao.mayadata.io",
+				"annotations": map[string]interface{}{
+					// refer to the object that triggered this creation
+					"doperator.dao.mayadata.io/uid": r.observedDOperator.UID,
+				},
+			},
+			"spec": map[string]interface{}{
+				"group":   "dao.mayadata.io",
+				"version": "v1alpha1",
+				"scope":   "Namespaced",
+				"names": map[string]interface{}{
+					"plural":   "directorhttps",
+					"singular": "directorhttp",
+					"kind":     "DirectorHTTP",
+					"shortNames": []interface{}{
+						"drhttp",
+					},
+				},
+			},
+		},
+	}
+	r.HookResponse.Attachments = append(
+		r.HookResponse.Attachments,
+		crd,
+	)
+}
+
+func (r *Reconciler) setDesiredCRDCStorPoolAuto() {
+	crd := &unstructured.Unstructured{
+		Object: map[string]interface{}{
+			"apiVersion": "apiextensions.k8s.io/v1beta1",
+			"kind":       "CustomResourceDefinition",
+			"metadata": map[string]interface{}{
+				"name": "cstorpoolautos.dao.mayadata.io",
+				"annotations": map[string]interface{}{
+					// refer to the object that triggered this creation
+					"doperator.dao.mayadata.io/uid": r.observedDOperator.UID,
+				},
+			},
+			"spec": map[string]interface{}{
+				"group":   "dao.mayadata.io",
+				"version": "v1alpha1",
+				"scope":   "Namespaced",
+				"names": map[string]interface{}{
+					"plural":   "cstorpoolautos",
+					"singular": "cstorpoolauto",
+					"kind":     "CStorPoolAuto",
+					"shortNames": []interface{}{
+						"cspauto",
+					},
+				},
+			},
+		},
+	}
+	r.HookResponse.Attachments = append(
+		r.HookResponse.Attachments,
+		crd,
+	)
+}
+
+func (r *Reconciler) setDesiredCRDs() {
+	r.setDesiredCRDBlockDeviceSet()
+	r.setDesiredCRDHTTP()
+	r.setDesiredCRDHTTPData()
+	r.setDesiredCRDCStorPoolCapacityRecommendation()
+	r.setDesiredCRDDirectorHTTP()
+	r.setDesiredCRDCStorPoolAuto()
+}
+
+// Sync implements the idempotent logic to sync HTTP
+//
+// NOTE:
+// 	SyncHookRequest is the payload received as part of reconcile
+// request. Similarly, SyncHookResponse is the payload sent as a
+// response as part of reconcile request.
+//
+// NOTE:
+//	This controller watches DOperator custom resource
+func Sync(request *generic.SyncHookRequest, response *generic.SyncHookResponse) error {
+	r := &Reconciler{}
+	r.HookRequest = request
+	r.HookResponse = response
+	// add functions to achieve desired state
+	r.ReconcileFns = []func(){
+		r.walkObservedDOperator,
+		r.setDesiredCRDs,
+	}
+	// add functions to achieve desired watch
+	r.DesiredWatchFns = []func(){}
+	// run reconcile
+	return r.Reconcile()
+}

--- a/go.mod
+++ b/go.mod
@@ -6,6 +6,7 @@ require (
 	github.com/go-resty/resty/v2 v2.2.0
 	github.com/golang/glog v0.0.0-20160126235308-23def4e6c14b
 	github.com/pkg/errors v0.9.1
+	github.com/tidwall/gjson v1.6.0
 	k8s.io/apimachinery v0.17.3
 	openebs.io/metac v0.1.1-0.20200207112147-5bfc4b3f4af9
 )

--- a/go.sum
+++ b/go.sum
@@ -279,6 +279,11 @@ github.com/stretchr/testify v1.2.2/go.mod h1:a8OnRcib4nhh0OaRAV+Yts87kKdq0PP7pXf
 github.com/stretchr/testify v1.3.0/go.mod h1:M5WIy9Dh21IEIfnGCwXGc5bZfKNJtfHm1UVUgZn+9EI=
 github.com/stretchr/testify v1.4.0 h1:2E4SXV/wtOkTonXsotYi4li6zVWxYlZuYNCXe9XRJyk=
 github.com/stretchr/testify v1.4.0/go.mod h1:j7eGeouHqKxXV5pUuKE4zz7dFj8WfuZ+81PSLYec5m4=
+github.com/tidwall/gjson v1.6.0 h1:9VEQWz6LLMUsUl6PueE49ir4Ka6CzLymOAZDxpFsTDc=
+github.com/tidwall/gjson v1.6.0/go.mod h1:P256ACg0Mn+j1RXIDXoss50DeIABTYK1PULOJHhxOls=
+github.com/tidwall/match v1.0.1 h1:PnKP62LPNxHKTwvHHZZzdOAOCtsJTjo6dZLCwpKm5xc=
+github.com/tidwall/match v1.0.1/go.mod h1:LujAq0jyVjBy028G1WhWfIzbpQfMO8bBZ6Tyb0+pL9E=
+github.com/tidwall/pretty v1.0.0 h1:HsD+QiTn7sK6flMKIvNmpqz1qrpP3Ps6jOKIKMooyg4=
 github.com/tidwall/pretty v1.0.0/go.mod h1:XNkn88O1ChpSDQmQeStsy+sBenx6DDtFZJxhVysOjyk=
 github.com/tmc/grpc-websocket-proxy v0.0.0-20170815181823-89b8d40f7ca8/go.mod h1:ncp9v5uamzpCO7NfCPTXjqaC+bZgJeR0sMTm6dMHP7U=
 github.com/ugorji/go/codec v0.0.0-20181204163529-d75b2dcb6bc8/go.mod h1:VFNgLljTbGfSG7qAOspJ7OScBnGdDN/yBr0sguwnwf0=

--- a/types/cstorpoolauto/types.go
+++ b/types/cstorpoolauto/types.go
@@ -20,26 +20,23 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
-const (
-	// BlockDeviceSetStatusOnline represents no errors at BlockDeviceSet
-	BlockDeviceSetStatusOnline string = "Online"
-
-	// BlockDeviceSetStatusError represent error at BlockDeviceSet
-	BlockDeviceSetStatusError string = "Error"
-)
-
-// BlockDeviceSet is a kubernetes custom resource that defines
-// the specifications to create one or more BlockDevices
-type BlockDeviceSet struct {
+// CStorPoolAuto is a kubernetes custom resource that defines
+// the specifications to manage CStorPoolAuto needs
+type CStorPoolAuto struct {
 	metav1.TypeMeta   `json:",inline"`
 	metav1.ObjectMeta `json:"metadata"`
 
-	Spec BlockDeviceSetSpec `json:"spec"`
+	Spec CStorPoolAutoSpec `json:"spec"`
 }
 
-// BlockDeviceSetSpec defines the configuration required
-// to create one or more BlockDevices
-type BlockDeviceSetSpec struct {
-	Device   map[string]interface{} `json:"device,omitempty"`
-	Replicas *int                   `json:"replicas,omitempty"`
+// CStorPoolAutoSpec defines the configuration required
+// to manage CStorPoolAuto
+type CStorPoolAutoSpec struct {
+	InstallRBAC             *bool  `json:"installRBAC,omitempty"`
+	InstallCRD              *bool  `json:"installCRD,omitempty"`
+	TargetNamespace         string `json:"targetNamespace"`
+	ServiceAccountName      string `json:"serviceAccountName"`
+	CStorPoolAutoImage      string `json:"cstorPoolAutoImage"`
+	StorageProvisionerImage string `json:"storageProvisionerImage"`
+	LogLevel                *int   `json:"logLevel,omitempty"`
 }

--- a/types/director/cstorpool.go
+++ b/types/director/cstorpool.go
@@ -1,0 +1,57 @@
+/*
+Copyright 2020 The MayaData Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    https://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package types
+
+import metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+const (
+	// HTTPStatusOnline represents no errors in CStorPoolCapacityRecommendation
+	HTTPStatusOnline string = "Online"
+
+	// HTTPStatusError represents errors in CStorPoolCapacityRecommendation
+	HTTPStatusError string = "Error"
+)
+
+const (
+	// URLRecommendationList is the URL to list the recommendations
+	URLRecommendationList string = URLDirector +
+		"/v3/groups/{group_id}/recommendations/"
+
+	// URLGetCSPCapacityRecommendation is the URL to get capacity
+	// based recommendation for cstor pool
+	URLGetCSPCapacityRecommendation string = URLDirector +
+		"/v3/groups/{group_id}/recommendations/{recommendation_csp_id}/?action=getcapacityrecommendation"
+)
+
+// CStorPoolCapacityRecommendation is a kubernetes custom resource that
+// defines the specifications to apply recommendation for cstorpool
+// based on capacity
+type CStorPoolCapacityRecommendation struct {
+	metav1.TypeMeta   `json:",inline"`
+	metav1.ObjectMeta `json:"metadata"`
+
+	Spec CStorPoolCapacityRecommendationSpec `json:"spec"`
+}
+
+// CStorPoolCapacityRecommendationSpec defines the configuration required
+// to apply recommendation for cstorpool based on capacity
+type CStorPoolCapacityRecommendationSpec struct {
+	HTTPDataName    string `json:"httpDataName"`
+	SecretName      string `json:"secretName"`
+	RAIDDeviceCount int    `json:"raidDeviceCount"`
+	RAIDType        string `json:"raidType"`
+}

--- a/types/director/http.go
+++ b/types/director/http.go
@@ -28,9 +28,9 @@ const (
 	URLActiveNodes string = URLDirector +
 		"/v3/groups/{group_id}/nodes?state=active&clusterId={cluster_id}"
 
-	// URLLabelNodes is the URL to label nodes
-	URLLabelNodes string = URLDirector +
-		"/v3/groups/{group_id}/nodes/{node_id}/?action=labelnodes"
+	// URLProjectDetails is the URL to fetch project details
+	URLProjectDetails string = URLDirector +
+		"/v3/groups/{group_id}/project"
 )
 
 const (
@@ -53,6 +53,9 @@ type DirectorHTTP struct {
 // DirectorHTTPSpec defines the configuration required
 // to invoke one or more Director APIs
 type DirectorHTTPSpec struct {
+	HTTPDataName string `json:"httpDataName"`
+	SecretName   string `json:"secretName"`
+
 	// Include the API names that should be invoked
 	//
 	// NOTE:
@@ -68,4 +71,8 @@ const (
 	// GetActiveNodes represent the Director API to fetch
 	// active node details
 	GetActiveNodes string = "get-active-nodes"
+
+	// GetProjectDetails represent the Director API to fetch
+	// project details
+	GetProjectDetails string = "get-project-details"
 )

--- a/types/doperator/types.go
+++ b/types/doperator/types.go
@@ -20,26 +20,9 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
-const (
-	// BlockDeviceSetStatusOnline represents no errors at BlockDeviceSet
-	BlockDeviceSetStatusOnline string = "Online"
-
-	// BlockDeviceSetStatusError represent error at BlockDeviceSet
-	BlockDeviceSetStatusError string = "Error"
-)
-
-// BlockDeviceSet is a kubernetes custom resource that defines
-// the specifications to create one or more BlockDevices
-type BlockDeviceSet struct {
+// DOperator is a kubernetes custom resource that defines
+// the specifications to manage CStorPoolAuto needs
+type DOperator struct {
 	metav1.TypeMeta   `json:",inline"`
 	metav1.ObjectMeta `json:"metadata"`
-
-	Spec BlockDeviceSetSpec `json:"spec"`
-}
-
-// BlockDeviceSetSpec defines the configuration required
-// to create one or more BlockDevices
-type BlockDeviceSetSpec struct {
-	Device   map[string]interface{} `json:"device,omitempty"`
-	Replicas *int                   `json:"replicas,omitempty"`
 }

--- a/types/gvk/gvk.go
+++ b/types/gvk/gvk.go
@@ -17,19 +17,29 @@ limitations under the License.
 package gvk
 
 const (
-	// KindHTTP is the resource kind for HTTP custom resource
+	// KindHTTP represents HTTP custom resource
 	KindHTTP string = "HTTP"
 
-	// KindHTTPData is the resource kind for HTTPData custom resource
+	// KindHTTPData represents HTTPData custom resource
 	KindHTTPData string = "HTTPData"
 
-	// KindDirectorHTTP is the resource kind for DirectorHTTP
-	// custom resource
+	// KindDirectorHTTP represents DirectorHTTP custom resource
 	KindDirectorHTTP string = "DirectorHTTP"
 )
 
 const (
-	// APIVersionDAOV1Alpha1 represents the dao group &
-	// v1alpha1 apiVersion
-	APIVersionDAOV1Alpha1 string = "dao.mayadata.io/v1alpha1"
+	// APIExtensionsK8sIOV1Beta1 represents apiextensions.k8s.io
+	// as group & v1beta1 as version
+	APIExtensionsK8sIOV1Beta1 string = "apiextensions.k8s.io/v1beta1"
+
+	// GroupDAOMayadataIO represents dao.mayadata.io as
+	// group
+	GroupDAOMayadataIO string = "dao.mayadata.io"
+
+	// VersionV1Alpha1 represents v1alpha1 version
+	VersionV1Alpha1 string = "v1alpha1"
+
+	// DAOMayadataIOV1Alpha1 represents
+	// dao.mayadata.io as group & v1alpha1 as version
+	DAOMayadataIOV1Alpha1 string = GroupDAOMayadataIO + "/" + VersionV1Alpha1
 )

--- a/types/http/types.go
+++ b/types/http/types.go
@@ -21,9 +21,11 @@ import (
 )
 
 const (
-	// LabelKeyHTTPDataName is the key used in labels to
-	// provides the name of HTTPData CR
-	LabelKeyHTTPDataName string = "httpdata-dao-mayadata-io/name"
+	// POST based http request
+	POST string = "post"
+
+	// GET based http request
+	GET string = "get"
 )
 
 // HTTP is a kubernetes custom resource that defines
@@ -33,25 +35,33 @@ type HTTP struct {
 	metav1.TypeMeta   `json:",inline"`
 	metav1.ObjectMeta `json:"metadata"`
 
-	Spec HTTPRequestSpec `json:"spec"`
+	Spec   HTTPRequestSpec   `json:"spec"`
+	Status HTTPRequestStatus `json:"status,omitempty"`
 }
-
-const (
-	// POST based http request
-	POST string = "post"
-
-	// GET based http request
-	GET string = "get"
-)
 
 // HTTPRequestSpec defines the configuration required
 // to invoke http request
 type HTTPRequestSpec struct {
-	URL     string            `json:"url"`
-	Method  string            `json:"method,omitempty"`
-	Headers map[string]string `json:"headers,omitempty"`
-	Params  map[string]string `json:"params,omitempty"`
-	Body    string            `json:"body,omitempty"`
+	SecretName  string            `json:"secretName"`
+	URL         string            `json:"url"`
+	Method      string            `json:"method,omitempty"`
+	Headers     map[string]string `json:"headers,omitempty"`
+	QueryParams map[string]string `json:"queryParams,omitempty"`
+	PathParams  map[string]string `json:"pathParams,omitempty"`
+	Body        string            `json:"body,omitempty"`
+}
+
+// HTTPRequestStatus has the status & response of an
+// invoked http URL
+type HTTPRequestStatus struct {
+	Phase          string                 `json:"phase"`
+	Reason         string                 `json:"reason"`
+	Warn           string                 `json:"warn"`
+	Completion     map[string]interface{} `json:"completion"`
+	Body           interface{}            `json:"body"`
+	HTTPStatusCode int                    `json:"httpStatusCode"`
+	HTTPStatus     string                 `json:"httpStatus"`
+	HTTPError      interface{}            `json:"httpError"`
 }
 
 const (
@@ -76,6 +86,6 @@ type HTTPData struct {
 // HTTPDataSpec defines the values required to invoke
 // http request
 type HTTPDataSpec struct {
-	PathParams map[string]string      `json:"params,omitempty"`
-	Values     map[string]interface{} `json:"values,omitempty"`
+	Headers    map[string]string `json:"headers,omitempty"`
+	PathParams map[string]string `json:"pathParams,omitempty"`
 }


### PR DESCRIPTION
This commit adds/updates following controllers:
- kind: HTTP as a declarative intent to invoke http requests
- kind: DirectorHTTP to invoke certain Director related http requests namely GetActiveNodes & GetProjectDetails
- kind: CStorPoolAuto to operate CStorPoolAuto related artifacts namely its CRDs, StatefulSets, ServiceAccount, ClusterRole & ClusterRoleBinding
- kind: DOperator to operate this repo related artifacts namely its CRDs
- kind: BlockDeviceSet to create one or more BlockDevices out of the specified template
- kind: CStorPoolCapacityRecommendation to provide a declarative way to specify capacity based recommendation to create CStorPoolCluster

_NOTE: Future commits will include various Unit Tests and Integration Tests on above features._

Signed-off-by: AmitKumarDas <amit.das@mayadata.io>