### PR TITLE
feat(run): add further unit tests to run resource

### DIFF
--- a/controller/run/createordelete.go
+++ b/controller/run/createordelete.go
@@ -32,7 +32,7 @@ type CreateOrDeleteRequest struct {
 	Watch             *unstructured.Unstructured
 	TaskKey           string
 	Apply             map[string]interface{}
-	Action            *types.Action
+	Replicas          *int
 	ObservedResources []*unstructured.Unstructured
 }
 
@@ -60,11 +60,11 @@ type CreateOrDeleteBuilder struct {
 }
 
 func (r *CreateOrDeleteBuilder) init() {
-	if r.Request.Action == nil || r.Request.Action.Replicas == nil {
+	if r.Request.Replicas == nil {
 		// default to single replica of the desired state
 		r.replicas = 1
 	} else {
-		r.replicas = *r.Request.Action.Replicas
+		r.replicas = *r.Request.Replicas
 	}
 }
 

--- a/controller/run/createordelete_test.go
+++ b/controller/run/createordelete_test.go
@@ -39,39 +39,31 @@ func TestInit(t *testing.T) {
 		},
 		"nil action": {
 			config: CreateOrDeleteRequest{
-				Action: nil,
+				Replicas: nil,
 			},
 			expectReplicas: 1,
 		},
 		"nil replicas": {
 			config: CreateOrDeleteRequest{
-				Action: &types.Action{
-					Replicas: nil,
-				},
+				Replicas: nil,
 			},
 			expectReplicas: 1,
 		},
 		"0 replicas": {
 			config: CreateOrDeleteRequest{
-				Action: &types.Action{
-					Replicas: ptr.Int(0),
-				},
+				Replicas: ptr.Int(0),
 			},
 			expectReplicas: 0,
 		},
 		"1 replicas": {
 			config: CreateOrDeleteRequest{
-				Action: &types.Action{
-					Replicas: ptr.Int(1),
-				},
+				Replicas: ptr.Int(1),
 			},
 			expectReplicas: 1,
 		},
 		"2 replicas": {
 			config: CreateOrDeleteRequest{
-				Action: &types.Action{
-					Replicas: ptr.Int(2),
-				},
+				Replicas: ptr.Int(2),
 			},
 			expectReplicas: 2,
 		},
@@ -769,7 +761,7 @@ func TestBuildCreateOrDeleteStates(t *testing.T) {
 						},
 					},
 				},
-				Action: &types.Action{},
+				Replicas: nil,
 				Apply: map[string]interface{}{
 					"kind":       "Pod",
 					"apiVersion": "v1",
@@ -816,9 +808,7 @@ func TestBuildCreateOrDeleteStates(t *testing.T) {
 						},
 					},
 				},
-				Action: &types.Action{
-					Replicas: ptr.Int(0),
-				},
+				Replicas: ptr.Int(0),
 				Apply: map[string]interface{}{
 					"kind":       "Pod",
 					"apiVersion": "v1",
@@ -854,9 +844,7 @@ func TestBuildCreateOrDeleteStates(t *testing.T) {
 						},
 					},
 				},
-				Action: &types.Action{
-					Replicas: ptr.Int(1),
-				},
+				Replicas: ptr.Int(1),
 				Apply: map[string]interface{}{
 					"kind":       "Pod",
 					"apiVersion": "v1",
@@ -903,9 +891,7 @@ func TestBuildCreateOrDeleteStates(t *testing.T) {
 						},
 					},
 				},
-				Action: &types.Action{
-					Replicas: ptr.Int(2),
-				},
+				Replicas: ptr.Int(2),
 				Apply: map[string]interface{}{
 					"kind":       "Pod",
 					"apiVersion": "v1",
@@ -986,9 +972,7 @@ func TestBuildCreateOrDeleteStates(t *testing.T) {
 						},
 					},
 				},
-				Action: &types.Action{
-					Replicas: ptr.Int(2), // replicas really dont matter
-				},
+				Replicas: ptr.Int(2), // replicas really dont matter
 				Apply: map[string]interface{}{
 					"kind":       "Pod",
 					"apiVersion": "v1",
@@ -1070,9 +1054,7 @@ func TestBuildCreateOrDeleteStates(t *testing.T) {
 						},
 					},
 				},
-				Action: &types.Action{
-					Replicas: ptr.Int(2), // replicas really dont matter
-				},
+				Replicas: ptr.Int(2), // replicas really dont matter
 				Apply: map[string]interface{}{
 					"kind":       "Pod",
 					"apiVersion": "v1",
@@ -1144,9 +1126,7 @@ func TestBuildCreateOrDeleteStates(t *testing.T) {
 						},
 					},
 				},
-				Action: &types.Action{
-					Replicas: ptr.Int(0), // implies delete
-				},
+				Replicas: ptr.Int(0), // implies delete
 				Apply: map[string]interface{}{
 					"kind":       "Pod",
 					"apiVersion": "v1",
@@ -1217,9 +1197,7 @@ func TestBuildCreateOrDeleteStates(t *testing.T) {
 						},
 					},
 				},
-				Action: &types.Action{
-					Replicas: ptr.Int(0), // implies delete
-				},
+				Replicas: ptr.Int(0), // implies delete
 				Apply: map[string]interface{}{
 					"kind":       "Pod",
 					"apiVersion": "v1",
@@ -1310,9 +1288,7 @@ func TestBuildCreateOrDeleteStates(t *testing.T) {
 						},
 					},
 				},
-				Action: &types.Action{
-					Replicas: ptr.Int(0), // implies delete
-				},
+				Replicas: ptr.Int(0), // implies delete
 				Apply: map[string]interface{}{
 					"kind":       "Pod",
 					"apiVersion": "v1",

--- a/controller/run/task.go
+++ b/controller/run/task.go
@@ -49,7 +49,6 @@ type RunnableTask struct {
 
 	isNilApply  bool
 	isNilUpdate bool
-	isNilAction bool
 	isNilAssert bool
 
 	isIfCondSuccess bool
@@ -67,9 +66,6 @@ func (r *RunnableTask) validate() {
 	}
 	if len(r.Request.Task.Apply) == 0 {
 		r.isNilApply = true
-	}
-	if r.Request.Task.Action == nil {
-		r.isNilAction = true
 	}
 	if r.Request.Task.Assert == nil {
 		r.isNilAssert = true
@@ -179,8 +175,8 @@ func (r *RunnableTask) runCreateOrDelete() {
 	resp, err := BuildCreateOrDeleteStates(CreateOrDeleteRequest{
 		Run:               r.Request.Run,
 		Watch:             r.Request.Watch,
-		Action:            r.Request.Task.Action,
 		Apply:             r.Request.Task.Apply,
+		Replicas:          r.Request.Task.Replicas,
 		ObservedResources: r.Request.ObservedResources,
 		TaskKey:           r.Request.Task.Key,
 	})

--- a/controller/run/task_test.go
+++ b/controller/run/task_test.go
@@ -648,9 +648,7 @@ func TestExecuteCreateTask(t *testing.T) {
 							},
 						},
 					},
-					Action: &types.Action{
-						Replicas: ptr.Int(5),
-					},
+					Replicas: ptr.Int(5),
 				},
 				ObservedResources: []*unstructured.Unstructured{
 					&unstructured.Unstructured{
@@ -690,9 +688,7 @@ func TestExecuteCreateTask(t *testing.T) {
 							},
 						},
 					},
-					Action: &types.Action{
-						Replicas: ptr.Int(5),
-					},
+					Replicas: ptr.Int(5),
 				},
 			},
 			expectedResp: TaskResponse{
@@ -768,9 +764,7 @@ func TestExecuteCreateTask(t *testing.T) {
 						"kind":       "Pod",
 						"apiVersion": "v1",
 					},
-					Action: &types.Action{
-						Replicas: ptr.Int(0), // 0 implies delete
-					},
+					Replicas: ptr.Int(0), // 0 implies delete
 				},
 				ObservedResources: []*unstructured.Unstructured{
 					&unstructured.Unstructured{
@@ -950,9 +944,7 @@ func TestExecuteCreateTask(t *testing.T) {
 						"kind":       "Pod",
 						"apiVersion": "v1",
 					},
-					Action: &types.Action{
-						Replicas: ptr.Int(0), // 0 implies delete
-					},
+					Replicas: ptr.Int(0), // 0 implies delete
 				},
 				ObservedResources: []*unstructured.Unstructured{},
 			},

--- a/types/run/types.go
+++ b/types/run/types.go
@@ -275,16 +275,15 @@ type Task struct {
 	// 	Apply is optional
 	Apply map[string]interface{} `json:"desired,omitempty"`
 
-	// Action that needs to be taken against the specified state
+	// Replicas when set to 0 implies **deletion** of resource
+	// at the cluster. Similarly, when set to some value that is
+	// greater than 1, implies applying multiple copies of the
+	// resource specified in **state** field.
 	//
-	// NOTE:
-	// 	Action acts upon the state. Action depends on Assert
-	// if set. If Assert fails, then action won't be executed
-	// on the state.
+	// Default value is 1
 	//
-	// NOTE:
-	// 	Action is optional
-	Action *Action `json:"action,omitempty"`
+	// Replicas is optional
+	Replicas *int `json:"replicas,omitempty"`
 
 	// The target(s) that get updated. Desired state found in
 	// Apply will be applied against the resources selected
@@ -310,18 +309,18 @@ type Task struct {
 	Assert *Assert `json:"assert,omitempty"`
 }
 
-// Action to be taken against the resource
-type Action struct {
-	// Replicas when set to 0 implies **deletion** of resource
-	// at the cluster. Similarly, when set to some value that is
-	// greater than 1, implies applying multiple copies of the
-	// resource specified in **state** field.
-	//
-	// Default value is 1
-	//
-	// Replicas is optional
-	Replicas *int `json:"replicas,omitempty"`
-}
+// // Action to be taken against the resource
+// type Action struct {
+// 	// Replicas when set to 0 implies **deletion** of resource
+// 	// at the cluster. Similarly, when set to some value that is
+// 	// greater than 1, implies applying multiple copies of the
+// 	// resource specified in **state** field.
+// 	//
+// 	// Default value is 1
+// 	//
+// 	// Replicas is optional
+// 	Replicas *int `json:"replicas,omitempty"`
+// }
 
 // Assert any condition or state of resource
 type Assert struct {


### PR DESCRIPTION
This commit also removes Action field from Run resource since it is no more requried. Replicas is now moved to be part of direct RunSpec schema.

Signed-off-by: AmitKumarDas <amit.das@mayadata.io>