### PR TITLE
feat(timeout): add job elapsed time

### DIFF
--- a/controller/job/reconciler.go
+++ b/controller/job/reconciler.go
@@ -17,7 +17,9 @@ limitations under the License.
 package job
 
 import (
+	"k8s.io/utils/pointer"
 	"openebs.io/metac/controller/generic"
+	k8s "openebs.io/metac/third_party/kubernetes"
 
 	commonctrl "mayadata.io/d-operators/common/controller"
 	"mayadata.io/d-operators/common/unstruct"
@@ -77,6 +79,9 @@ func (r *Reconciler) setWatchStatusAsError() {
 		"phase":  "Error",
 		"reason": r.Err.Error(),
 	}
+	r.HookResponse.Labels = map[string]*string{
+		"job.dope.metacontroller.io/phase": k8s.StringPtr("Error"),
+	}
 }
 
 func (r *Reconciler) setWatchStatusFromJobStatus() {
@@ -87,6 +92,9 @@ func (r *Reconciler) setWatchStatusFromJobStatus() {
 		"failedTaskCount": int64(r.JobStatus.FailedTaskCount),
 		"taskCount":       int64(r.JobStatus.TaskCount),
 		"taskListStatus":  r.JobStatus.TaskListStatus,
+	}
+	r.HookResponse.Labels = map[string]*string{
+		"job.dope.metacontroller.io/phase": pointer.StringPtr(string(r.JobStatus.Phase)),
 	}
 }
 

--- a/go.mod
+++ b/go.mod
@@ -13,6 +13,7 @@ require (
 	k8s.io/apimachinery v0.17.3
 	k8s.io/client-go v0.17.3
 	k8s.io/klog/v2 v2.0.0
+	k8s.io/utils v0.0.0-20191114184206-e782cd3c129f
 	openebs.io/metac v0.3.0
 )
 

--- a/pkg/job/assert.go
+++ b/pkg/job/assert.go
@@ -102,6 +102,7 @@ func (a *Assertable) runAssertByPath() {
 		Message: got.Message,
 		Verbose: got.Verbose,
 		Warning: got.Warning,
+		Timeout: got.Timeout,
 	}
 }
 
@@ -125,6 +126,7 @@ func (a *Assertable) runAssertByState() {
 		Message: got.Message,
 		Verbose: got.Verbose,
 		Warning: got.Warning,
+		Timeout: got.Timeout,
 	}
 }
 

--- a/pkg/job/create.go
+++ b/pkg/job/create.go
@@ -1,0 +1,271 @@
+/*
+Copyright 2020 The MayaData Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    https://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package job
+
+import (
+	"fmt"
+
+	"github.com/pkg/errors"
+	"k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1beta1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	types "mayadata.io/d-operators/types/job"
+	"openebs.io/metac/dynamic/clientset"
+)
+
+// CreatableConfig helps in creating new instance of Creatable
+type CreatableConfig struct {
+	Fixture  *Fixture
+	Retry    *Retryable
+	Create   *types.Create
+	TaskName string
+}
+
+// Creatable helps creating desired state(s) against the cluster
+type Creatable struct {
+	*Fixture
+	Retry    *Retryable
+	TaskName string
+	Create   *types.Create
+
+	result *types.CreateResult
+	err    error
+}
+
+func (c *Creatable) String() string {
+	if c.Create == nil {
+		return ""
+	}
+	return fmt.Sprintf(
+		"Create action: Resource %s %s: GVK %s: TaskName %s",
+		c.Create.State.GetNamespace(),
+		c.Create.State.GetName(),
+		c.Create.State.GroupVersionKind(),
+		c.TaskName,
+	)
+}
+
+// NewCreator returns a new instance of Creatable
+func NewCreator(config CreatableConfig) *Creatable {
+	return &Creatable{
+		Create:   config.Create,
+		Fixture:  config.Fixture,
+		Retry:    config.Retry,
+		TaskName: config.TaskName,
+		result:   &types.CreateResult{},
+	}
+}
+
+func (c *Creatable) postCreateCRD(
+	crd *v1beta1.CustomResourceDefinition,
+) error {
+	message := fmt.Sprintf(
+		"PostCreate CRD: Kind %s: APIVersion %s: TaskName %s",
+		crd.Spec.Names.Singular,
+		crd.Spec.Group+"/"+crd.Spec.Version,
+		c.TaskName,
+	)
+	// discover custom resource API
+	return c.Retry.Waitf(
+		func() (bool, error) {
+			got := c.apiDiscovery.
+				GetAPIForAPIVersionAndResource(
+					crd.Spec.Group+"/"+crd.Spec.Version,
+					crd.Spec.Names.Plural,
+				)
+			if got == nil {
+				return false, errors.Errorf(
+					"Failed to discover: Kind %s: APIVersion %s",
+					crd.Spec.Names.Singular,
+					crd.Spec.Group+"/"+crd.Spec.Version,
+				)
+			}
+			// fetch dynamic client for the custom resource
+			// corresponding to this CRD
+			customResourceClient, err := c.dynamicClientset.
+				GetClientForAPIVersionAndResource(
+					crd.Spec.Group+"/"+crd.Spec.Version,
+					crd.Spec.Names.Plural,
+				)
+			if err != nil {
+				return false, err
+			}
+			_, err = customResourceClient.List(metav1.ListOptions{})
+			if err != nil {
+				return false, err
+			}
+			return true, nil
+		},
+		message,
+	)
+}
+
+func (c *Creatable) createCRD() (*types.CreateResult, error) {
+	var crd *v1beta1.CustomResourceDefinition
+	err := UnstructToTyped(c.Create.State, &crd)
+	if err != nil {
+		return nil, err
+	}
+	// use crd client to create crd
+	crd, err = c.crdClient.
+		CustomResourceDefinitions().
+		Create(crd)
+	if err != nil {
+		return nil, errors.Wrapf(err, "%s", c)
+	}
+	// add to teardown functions
+	c.AddToTeardown(func() error {
+		_, err := c.crdClient.
+			CustomResourceDefinitions().
+			Get(
+				crd.GetName(),
+				metav1.GetOptions{},
+			)
+		if err != nil && apierrors.IsNotFound(err) {
+			// nothing to do
+			return nil
+		}
+		return c.crdClient.
+			CustomResourceDefinitions().
+			Delete(
+				crd.Name,
+				nil,
+			)
+	})
+	// run an additional step to wait till this CRD
+	// is discovered at apiserver
+	err = c.postCreateCRD(crd)
+	if err != nil {
+		return nil, err
+	}
+	return &types.CreateResult{
+		Phase: types.CreateStatusPassed,
+		Message: fmt.Sprintf(
+			"Create CRD: Kind %s: APIVersion %s",
+			crd.Spec.Names.Singular,
+			crd.Spec.Group+"/"+crd.Spec.Version,
+		),
+	}, nil
+}
+
+func (c *Creatable) createResource(
+	obj *unstructured.Unstructured,
+	client *clientset.ResourceClient,
+) error {
+	_, err := client.
+		Namespace(obj.GetNamespace()).
+		Create(
+			obj,
+			metav1.CreateOptions{},
+		)
+	if err != nil {
+		return err
+	}
+	c.AddToTeardown(func() error {
+		_, err := client.
+			Namespace(obj.GetNamespace()).
+			Get(
+				obj.GetName(),
+				metav1.GetOptions{},
+			)
+		if err != nil && apierrors.IsNotFound(err) {
+			// nothing to do since resource is already deleted
+			return nil
+		}
+		return client.
+			Namespace(obj.GetNamespace()).
+			Delete(
+				obj.GetName(),
+				&metav1.DeleteOptions{},
+			)
+	})
+	return nil
+}
+
+func buildNamesFromGivenState(
+	obj *unstructured.Unstructured,
+	replicas int,
+) ([]string, error) {
+	var name string
+	name = obj.GetGenerateName()
+	if name == "" {
+		name = obj.GetName()
+	}
+	if name == "" {
+		return nil, errors.Errorf(
+			"Failed to generate names: Either name or generateName required",
+		)
+	}
+	if replicas == 1 {
+		return []string{name}, nil
+	}
+	var out []string
+	for i := 0; i < replicas; i++ {
+		out = append(out, fmt.Sprintf("%s-%d", name, i))
+	}
+	return out, nil
+}
+
+func (c *Creatable) createResourceReplicas() (*types.CreateResult, error) {
+	replicas := 1
+	if c.Create.Replicas != nil {
+		replicas = *c.Create.Replicas
+	}
+	if replicas <= 0 {
+		return nil, errors.Errorf(
+			"Failed to create: Invalid replicas %d: %s",
+			replicas,
+			c,
+		)
+	}
+	client, err := c.dynamicClientset.
+		GetClientForAPIVersionAndKind(
+			c.Create.State.GetAPIVersion(),
+			c.Create.State.GetKind(),
+		)
+	if err != nil {
+		return nil, err
+	}
+	names, err := buildNamesFromGivenState(c.Create.State, replicas)
+	if err != nil {
+		return nil, errors.Wrapf(err, "%s", c)
+	}
+	for _, name := range names {
+		obj := &unstructured.Unstructured{
+			Object: c.Create.State.Object,
+		}
+		obj.SetName(name)
+		err = c.createResource(obj, client)
+		if err != nil {
+			return nil, errors.Wrapf(err, "%s", c)
+		}
+	}
+	return &types.CreateResult{
+		Phase:   types.CreateStatusPassed,
+		Message: c.String(),
+	}, nil
+}
+
+// Run creates the desired state against the cluster
+func (c *Creatable) Run() (*types.CreateResult, error) {
+	if c.Create.State.GetKind() == "CustomResourceDefinition" {
+		// create CRD
+		return c.createCRD()
+	}
+	return c.createResourceReplicas()
+}

--- a/pkg/job/state_check.go
+++ b/pkg/job/state_check.go
@@ -230,7 +230,7 @@ func (sc *StateChecking) assertNotFound() {
 		sc.State.GroupVersionKind(),
 		sc.TaskName,
 	)
-	var warning, verbose string
+	var warning string
 	// init result to Failed
 	var phase = types.StateCheckResultFailed
 	err := sc.Retry.Waitf(
@@ -277,12 +277,11 @@ func (sc *StateChecking) assertNotFound() {
 			sc.err = err
 			return
 		}
-		verbose = err.Error()
+		sc.result.Timeout = err.Error()
 	}
 	sc.result.Phase = phase
 	sc.result.Message = message
 	sc.result.Warning = warning
-	sc.result.Verbose = verbose
 }
 
 func (sc *StateChecking) isListCountMatch() (bool, error) {
@@ -316,7 +315,6 @@ func (sc *StateChecking) assertListCountEquals() {
 		sc.State.GroupVersionKind(),
 		sc.TaskName,
 	)
-	var verbose string
 	// init result to Failed
 	var phase = types.StateCheckResultFailed
 	err := sc.Retry.Waitf(
@@ -340,7 +338,7 @@ func (sc *StateChecking) assertListCountEquals() {
 			sc.err = err
 			return
 		}
-		verbose = err.Error()
+		sc.result.Timeout = err.Error()
 	}
 	sc.result.Phase = phase
 	sc.result.Message = message
@@ -349,7 +347,6 @@ func (sc *StateChecking) assertListCountEquals() {
 		*sc.StateCheck.Count,
 		sc.actualListCount,
 	)
-	sc.result.Verbose = verbose
 }
 
 func (sc *StateChecking) assertListCountNotEquals() {
@@ -359,7 +356,6 @@ func (sc *StateChecking) assertListCountNotEquals() {
 		sc.State.GroupVersionKind(),
 		sc.TaskName,
 	)
-	var verbose string
 	// init result to Failed
 	var phase = types.StateCheckResultFailed
 	err := sc.Retry.Waitf(
@@ -383,7 +379,7 @@ func (sc *StateChecking) assertListCountNotEquals() {
 			sc.err = err
 			return
 		}
-		verbose = err.Error()
+		sc.result.Timeout = err.Error()
 	}
 	sc.result.Phase = phase
 	sc.result.Message = message
@@ -392,7 +388,6 @@ func (sc *StateChecking) assertListCountNotEquals() {
 		*sc.StateCheck.Count,
 		sc.actualListCount,
 	)
-	sc.result.Verbose = verbose
 }
 
 func (sc *StateChecking) assert() {

--- a/test/experiments/create-assert-fifty-configmaps-elapsedtime.yaml
+++ b/test/experiments/create-assert-fifty-configmaps-elapsedtime.yaml
@@ -1,0 +1,52 @@
+apiVersion: metacontroller.app/v1
+kind: Job
+metadata:
+  name: create-fifty-configmaps
+  namespace: d-testing
+spec:
+  tasks:
+  - name: create-fifty-configmaps
+    create: 
+      state: 
+        kind: ConfigMap
+        apiVersion: v1
+        metadata:
+          name: create-cm-elapsed-time
+          namespace: d-testing
+      replicas: 50
+---
+apiVersion: metacontroller.app/v1
+kind: Job
+metadata:
+  name: assert-creation-of-fifty-configmaps-elapsed-time
+  namespace: d-testing
+  labels:
+    d-testing.metacontroller.app/enabled: "true"
+spec:
+  tasks:
+  - name: assert-create-fifty-configmaps-job-completed
+    assert: 
+      state: 
+        kind: Job
+        apiVersion: metacontroller.app/v1
+        metadata:
+          name: create-fifty-configmaps
+          namespace: d-testing
+        status:
+          phase: Completed
+  - name: assert-creation-of-fifty-configmaps-within-time
+    assert: 
+      state: 
+        kind: Job
+        apiVersion: metacontroller.app/v1
+        metadata:
+          name: create-fifty-configmaps
+          namespace: d-testing
+      pathCheck:
+        path: status.taskListStatus.job-elapsed-time.elapsedTimeInSeconds
+        pathCheckOperator: LTE
+        # assert if the entire experiment of creating 50 configmaps
+        # completes in around 10 seconds
+        value: 10.001
+        dataType: float64
+---

--- a/test/experiments/create-assert-fifty-configmaps.yaml
+++ b/test/experiments/create-assert-fifty-configmaps.yaml
@@ -1,0 +1,35 @@
+apiVersion: metacontroller.app/v1
+kind: Job
+metadata:
+  name: create-assert-fifty-configmaps
+  namespace: d-testing
+  labels:
+    d-testing.metacontroller.app/enabled: "true"
+spec:
+  tasks:
+  - name: create-fifty-configmaps
+    create: 
+      state: 
+        kind: ConfigMap
+        apiVersion: v1
+        metadata:
+          name: create-cm
+          namespace: d-testing
+      replicas: 50
+  - name: assert-presence-of-0th-configmap
+    assert: 
+      state: 
+        kind: ConfigMap
+        apiVersion: v1
+        metadata:
+          name: create-cm-0
+          namespace: d-testing
+  - name: assert-presence-of-49th-configmap
+    assert: 
+      state: 
+        kind: ConfigMap
+        apiVersion: v1
+        metadata:
+          name: create-cm-49
+          namespace: d-testing
+---

--- a/test/experiments/inference.yaml
+++ b/test/experiments/inference.yaml
@@ -1,27 +1,53 @@
 # This is an internal job used by test suite runner
-# to evaluate if other jobs were successful or failed
+# to evaluate if desired experiments were successful
+# or not
 apiVersion: metacontroller.app/v1
 kind: Job
 metadata:
-  name: inference # do-not-change
-  namespace: d-testing # do-not-change
+  # should match setup.yaml 
+  name: inference # matches spec.test.inference.experimentName
+  namespace: d-testing # matches spec.test.inference.experimentNamespace
   labels:
     d-testing.metacontroller.app/internal: "true"
 spec:
   tasks:
-  # This is also an example of a Job making use of another
-  # Job as its task
   - name: assert-all-tests-are-completed
     assert: 
       state: 
         kind: Job
         apiVersion: metacontroller.app/v1
         metadata:
+          namespace: d-testing
           labels:
             d-testing.metacontroller.app/enabled: "true"
-        status:
-          phase: Completed
+            job.dope.metacontroller.io/phase: Completed
       stateCheck:
         stateCheckOperator: ListCountEquals
-        count: 5 # number of successfully completed tests i.e. jobs
+        count: 7
+  - name: assert-no-tests-have-failed
+    assert: 
+      state: 
+        kind: Job
+        apiVersion: metacontroller.app/v1
+        metadata:
+          namespace: d-testing
+          labels:
+            d-testing.metacontroller.app/enabled: "true"
+            job.dope.metacontroller.io/phase: Failed
+      stateCheck:
+        stateCheckOperator: ListCountEquals
+        count: 0
+  - name: assert-no-tests-have-errored
+    assert: 
+      state: 
+        kind: Job
+        apiVersion: metacontroller.app/v1
+        metadata:
+          namespace: d-testing
+          labels:
+            d-testing.metacontroller.app/enabled: "true"
+            job.dope.metacontroller.io/phase: Error
+      stateCheck:
+        stateCheckOperator: ListCountEquals
+        count: 0
 ---

--- a/types/job/apply.go
+++ b/types/job/apply.go
@@ -77,7 +77,7 @@ const (
 	ApplyStatusFailed ApplyStatusPhase = "Failed"
 )
 
-// ToTaskStatusPhase transforms ApplyResultPhase to TestResultPhase
+// ToTaskStatusPhase transforms ApplyStatusPhase to TestResultPhase
 func (phase ApplyStatusPhase) ToTaskStatusPhase() TaskStatusPhase {
 	switch phase {
 	case ApplyStatusPassed:

--- a/types/job/assert.go
+++ b/types/job/assert.go
@@ -83,6 +83,7 @@ type AssertStatus struct {
 	Message string            `json:"message,omitempty"`
 	Verbose string            `json:"verbose,omitempty"`
 	Warning string            `json:"warning,omitempty"`
+	Timeout string            `json:"timeout,omitempty"`
 }
 
 // AssertCheckType defines the type of assert check

--- a/types/job/create.go
+++ b/types/job/create.go
@@ -17,6 +17,8 @@ limitations under the License.
 package types
 
 import (
+	"encoding/json"
+
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 )
 
@@ -24,4 +26,57 @@ import (
 type Create struct {
 	// Desired state that needs to be created
 	State *unstructured.Unstructured `json:"state"`
+
+	// Desired count that needs to be created
+	Replicas *int `json:"replicas,omitempty"`
+}
+
+// String implements the Stringer interface
+func (a Create) String() string {
+	raw, err := json.MarshalIndent(
+		a,
+		" ",
+		".",
+	)
+	if err != nil {
+		panic(err)
+	}
+	return string(raw)
+}
+
+// CreateStatusPhase is a typed definition to determine the
+// result of executing a create
+type CreateStatusPhase string
+
+const (
+	// CreateStatusPassed defines a successful create
+	CreateStatusPassed CreateStatusPhase = "Passed"
+
+	// CreateStatusWarning defines a create that resulted in warnings
+	CreateStatusWarning CreateStatusPhase = "Warning"
+
+	// CreateStatusFailed defines a failed create
+	CreateStatusFailed CreateStatusPhase = "Failed"
+)
+
+// ToTaskStatusPhase transforms CreateStatusPhase to TestResultPhase
+func (phase CreateStatusPhase) ToTaskStatusPhase() TaskStatusPhase {
+	switch phase {
+	case CreateStatusPassed:
+		return TaskStatusPassed
+	case CreateStatusFailed:
+		return TaskStatusFailed
+	case CreateStatusWarning:
+		return TaskStatusWarning
+	default:
+		return ""
+	}
+}
+
+// CreateResult holds the result of the create operation
+type CreateResult struct {
+	Phase   CreateStatusPhase `json:"phase"`
+	Message string            `json:"message,omitempty"`
+	Verbose string            `json:"verbose,omitempty"`
+	Warning string            `json:"warning,omitempty"`
 }

--- a/types/job/patch_check.go
+++ b/types/job/patch_check.go
@@ -143,4 +143,5 @@ type PathCheckResult struct {
 	Message string               `json:"message,omitempty"`
 	Verbose string               `json:"verbose,omitempty"`
 	Warning string               `json:"warning,omitempty"`
+	Timeout string               `json:"timeout,omitempty"`
 }

--- a/types/job/state_check.go
+++ b/types/job/state_check.go
@@ -88,4 +88,5 @@ type StateCheckResult struct {
 	Message string                `json:"message,omitempty"`
 	Verbose string                `json:"verbose,omitempty"`
 	Warning string                `json:"warning,omitempty"`
+	Timeout string                `json:"timeout,omitempty"`
 }

--- a/types/job/task.go
+++ b/types/job/task.go
@@ -60,10 +60,12 @@ const (
 
 // TaskStatus holds task execution details
 type TaskStatus struct {
-	Step     int             `json:"step"`
-	Phase    TaskStatusPhase `json:"phase"`
-	Internal *bool           `json:"internal,omitempty"`
-	Message  string          `json:"message,omitempty"`
-	Verbose  string          `json:"verbose,omitempty"`
-	Warning  string          `json:"warning,omitempty"`
+	Step                 int             `json:"step"`
+	Phase                TaskStatusPhase `json:"phase"`
+	ElapsedTimeInSeconds *float64        `json:"elapsedTimeInSeconds,omitempty"`
+	Internal             *bool           `json:"internal,omitempty"`
+	Message              string          `json:"message,omitempty"`
+	Verbose              string          `json:"verbose,omitempty"`
+	Warning              string          `json:"warning,omitempty"`
+	Timeout              string          `json:"timeout,omitempty"`
 }


### PR DESCRIPTION
This commit adds support to set a job's elapsed time. This may be used to assert if a job got executed within some desired time interval.

An experiment has been added that verifies if 50 config maps get created by a job and all of this should happen within 10 seconds.

In addition, several fixes and minor enhancement have gone in to make Job more usable to write testcase implementations.

Signed-off-by: AmitKumarDas <amit.das@mayadata.io>