### PR TITLE
fix(recipe): fix issues due to job to recipe change

### DIFF
--- a/.github/workflows/release-docker.yaml
+++ b/.github/workflows/release-docker.yaml
@@ -1,17 +1,17 @@
 ---
-name: Release docker image
+name: Release Docker Image
 on:
   push:
     tags:
       - 'v[0-9]+.[0-9]+.[0-9]+'
 jobs:
   release-docker:
-    name: Release docker image
+    name: Release Docker Image
     runs-on: ubuntu-18.04
     steps:
-      - name: Checkout
+      - name: Checkout Code
         uses: actions/checkout@v2
-      - name: Deploy docker image
+      - name: Setup Docker
         uses: docker/build-push-action@v1
         with:
           username: ${{ secrets.DOCKER_USERNAME }}

--- a/.github/workflows/test-release.yaml
+++ b/.github/workflows/test-release.yaml
@@ -1,39 +1,57 @@
 ---
-name: Test and Release (if on master)
+name: Unit Test, E to E Test and Github Release (if on master)
 on: [push, pull_request]
 jobs:
-  tests:
+  unittest:
     runs-on: ubuntu-18.04
     strategy:
       matrix:
         test: ['test']
     name: ${{ matrix.test }}
     steps:
-      - name: Checkout
+      - name: Checkout Code
         uses: actions/checkout@v2
-      - name: setup env
+      - name: Setup GOPATH
         run: |
           echo "::set-env name=GOPATH::$(go env GOPATH)"
           echo "::add-path::$(go env GOPATH)/bin"
-      - name: Setup go
+      - name: Setup Golang
         uses: actions/setup-go@v1
         with:
           go-version: 1.13.5
       - run: make ${{ matrix.test }}
-  release:
-    name: Release
+  e2etest:
     runs-on: ubuntu-18.04
-    needs: ['tests']
+    strategy:
+      matrix:
+        test: ['e2e-test']
+    name: ${{ matrix.test }}
     steps:
-      - name: Checkout
+      - name: Checkout Code
+        uses: actions/checkout@v2
+      - name: Setup GOPATH
+        run: |
+          echo "::set-env name=GOPATH::$(go env GOPATH)"
+          echo "::add-path::$(go env GOPATH)/bin"
+      - name: Setup Golang
+        uses: actions/setup-go@v1
+        with:
+          go-version: 1.13.5
+      - run: sudo make ${{ matrix.test }}
+  release:
+    name: Make Github Release
+    runs-on: ubuntu-18.04
+    needs: ['unittest', 'e2etest']
+    steps:
+      - name: Checkout Code
         uses: actions/checkout@v1
       - name: Setup Node.js
         uses: actions/setup-node@v1
         with:
           node-version: 12
-      - name: Install dependencies
+      - name: Install NPM Dependencies to Make Release
         run: npm install ci
-      - name: Release
+      - name: Make Semantic Release
         env:
           GH_TOKEN: ${{ secrets.PAT }}
         run: npx semantic-release

--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@
 d-operators
 test/bin/
 test/kubebin/
+test/e2e/uninstall-k3s.txt

--- a/Dockerfile
+++ b/Dockerfile
@@ -28,7 +28,6 @@ COPY common/ common/
 COPY config/ config/
 COPY controller/ controller/
 COPY pkg/ pkg/
-COPY test/ test/
 COPY types/ types/
 
 # test d-operators
@@ -64,11 +63,6 @@ COPY config/ config/
 COPY controller/ controller/
 COPY pkg/ pkg/
 COPY types/ types/
-
-# we run the test once again since this is one of the
-# ways to remind copying new source packages into this 
-# build stage
-RUN make test
 
 # build binary
 RUN make

--- a/Makefile
+++ b/Makefile
@@ -41,11 +41,14 @@ test:
 testv:
 	@go test ./... -cover -v -args --logtostderr -v=2
 
+.PHONY: e2e-test
+e2e-test: 
+	@cd test/e2e && ./suite.sh
+
 .PHONY: image
 image: $(GIT_TAGS)
 	docker build -t $(IMG_REPO):$(PACKAGE_VERSION) .
 
-
 .PHONY: push
 push: image
-	docker push $(IMG_REPO):$(PACKAGE_VERSION)
+	docker push $(IMG_REPO):$(PACKAGE_VERSION

--- a/README.md
+++ b/README.md
@@ -1,20 +1,42 @@
-## d-operators
+## D-operators
 D-operators define various declarative patterns to write kubernetes controllers. This uses [metac](https://github.com/AmitKumarDas/metac/) under the hood. Users can _create_, _delete_, _update_, _assert_, _patch_, _clone_, & _schedule_ one or more kubernetes resources _(native as well as custom)_ using a yaml file. D-operators expose a bunch of kubernetes custom resources that provide the building blocks to implement a higher order controller.
 
 D-operators follow a pure intent based approach to writing specifications **instead of** having to deal with yamls that are cluttered with scripts, kubectl, loops, conditions, templating and so on.
 
 ### Programmatic vs. Declarative
-It is important to understand that these declarative patterns are built upon programmatic ones. The low level constructs _(read native k8s resources & custom resources)_ might be implemented in programming language(s) of one's choice. Use d-controller's YAMLs to aggregate these low level resources in a particular way to build a completely new kubernetes controller.
+It is important to understand that these declarative patterns are built upon programmatic ones. The low level constructs _(read native Kubernetes resources & custom resources)_ might be implemented in programming language(s) of one's choice. Use d-controller's YAMLs to aggregate these low level resources in a particular way to build a completely new kubernetes controller.
 
-### When to use d-operators
-D-operators is not meant to build complex controllers like Deployment, StatefulSet or Pod in a declarative yaml. However, if one needs to use Deployment, StatefulSet, Pod, etc. to build new k8s controller(s) then d-operators' declarative constructs _(read custom resources)_ should be considered to build one. 
+### When to use D-operators
+D-operators is not meant to build complex controller logic like Deployment, StatefulSet or Pod in a declarative yaml. However, if one needs to use available Kubernetes resources to build new k8s controller(s) then d-operators should be considered to build one. D-operators helps implement the last mile automation needed to manage applications & infrastructure in Kubernetes clusters.
 
-However, any controller which is complex and at the same time is **generic** enough to be used along with other kubernetes resources, can be implemented as a core d-operator custom resource.
+### E to E testing
+D-operators make use of d-operators _(i.e. its own self)_ to test its controllers. It does not need kubectl, bash, sed, awk etc to test its controllers. In addition, it does not depend on writing go code to write tests. It makes use of declarative YAMLs to test its controllers.
 
-### Available controllers
+_NOTE: One can make use of these YAMLs (kind: Recipe) to test any Kubernetes controllers declaratively_
+
+Navigate to test/experiments to learn more on these YAMLs.
+
+```sh
+# Following runs the e2e test suite
+#
+# NOTE: test/e2e/suite.sh does the following:
+# - d-operators' image known as 'dope' is built
+# - a docker container is started & acts as the image registry
+# - dope image is pushed to this image registry
+# - k3s is installed with above image registry
+# - d-operators' manifests are applied
+# - experiments _(i.e. test code written as YAMLs)_ are applied
+# - experiments are asserted
+# - if all experiments pass then e2e is a success else it failed
+# - k3s is un-installed
+# - local image registry is stopped
+sudo make e2e-test
+```
+
+### Available Kubernetes controllers
 - [x] kind: Recipe
 - [ ] kind: HTTP
-- [ ] kind: Chef
+- [ ] kind: HTTPPipe
 - [ ] kind: Command
 - [ ] kind: DaemonJob
-- [ ] kind: MasterChef
+- [ ] kind: UberLoop

--- a/config/metac.yaml
+++ b/config/metac.yaml
@@ -1,14 +1,14 @@
 apiVersion: metac.openebs.io/v1alpha1
 kind: GenericController
 metadata:
-  name: sync-job
+  name: sync-recipe
   namespace: dope
 spec:
-  watch:
-    apiVersion: metacontroller.app/v1
-    resource: jobs
+  watch: # kind: Recipe custom resource is watched
+    apiVersion: dope.metacontroller.io/v1
+    resource: recipes
   hooks:
     sync:
       inline:
-        funcName: sync/job
+        funcName: sync/recipe
 ---

--- a/controller/http/reconciler.go
+++ b/controller/http/reconciler.go
@@ -22,42 +22,47 @@ import (
 
 	"github.com/pkg/errors"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
-
-	resty "github.com/go-resty/resty/v2"
 	"openebs.io/metac/controller/generic"
 
 	ctrlutil "mayadata.io/d-operators/common/controller"
 	"mayadata.io/d-operators/common/unstruct"
+	"mayadata.io/d-operators/pkg/http"
 	types "mayadata.io/d-operators/types/http"
-)
-
-const (
-	// SecretTypeBasicAuth refers to basic authentication based secret
-	SecretTypeBasicAuth string = "kubernetes.io/basic-auth"
-
-	// BasicAuthUsernameKey is the key of the username for
-	// SecretTypeBasicAuth secrets
-	BasicAuthUsernameKey = "username"
-
-	// BasicAuthPasswordKey is the key of the password or token for
-	// SecretTypeBasicAuth secrets
-	BasicAuthPasswordKey = "password"
 )
 
 // Reconciler manages reconciliation of HTTP resources
 type Reconciler struct {
+	// common Reconciler is embedded to enable using its
+	// properties & methods
 	ctrlutil.Reconciler
 
-	observedHTTP       *types.HTTP
-	observedSecretName string
-	observedSecret     *unstructured.Unstructured
-	observedUsername   string
-	observedPassword   string
+	// http object that is received as part of reconciliation
+	observedHTTP *types.HTTP
 
-	response *resty.Response
+	// secret object that is received as part of reconciliation
+	observedSecret *unstructured.Unstructured
+
+	// name of the secret that is received as part of reconciliation
+	observedSecretName string
+
+	// username to invoke authenticated APIs
+	observedUsername string
+	// passwrod to invoke authenticated APIs
+	observedPassword string
+
+	// response received after invoking the http request
+	response types.HTTPResponse
 }
 
-func (r *Reconciler) walkObservedHTTP() {
+// evalObservedHTTP tranforms the HTTP custom resource observed in Kubernetes
+// cluster to its corresponding typed definition. The observed HTTP
+// resource is received as an unstructured instance. Unstructured instances are
+// not friendly to parse. Hence, the need for this method.
+//
+// NOTE:
+//	Executing this method does not imply catching validation errors found
+// in HTTP custom resource
+func (r *Reconciler) evalObservedHTTP() {
 	var http types.HTTP
 	err := unstruct.ToTyped(
 		r.HookRequest.Watch,
@@ -68,6 +73,8 @@ func (r *Reconciler) walkObservedHTTP() {
 		return
 	}
 	r.observedHTTP = &http
+
+	// validate presence of secret
 	r.observedSecretName = http.Spec.SecretName
 	if r.observedSecretName == "" {
 		r.Err = errors.Errorf("Missing spec.secretName")
@@ -75,7 +82,9 @@ func (r *Reconciler) walkObservedHTTP() {
 	}
 }
 
-func (r *Reconciler) walkObservedSecret() {
+// evalObservedSecret parses the relevant secret found in Kubernetes
+// cluster. This secret is used to authenticate the request invocation.
+func (r *Reconciler) evalObservedSecret() {
 	r.observedSecret = r.HookRequest.Attachments.FindByGroupKindName(
 		"v1",
 		"Secret",
@@ -83,7 +92,7 @@ func (r *Reconciler) walkObservedSecret() {
 	)
 	if r.observedSecret == nil {
 		r.Err = errors.Errorf(
-			"Secret %q not found",
+			"Secret not found: Name %q",
 			r.observedSecretName,
 		)
 		return
@@ -98,6 +107,7 @@ func (r *Reconciler) walkObservedSecret() {
 		r.HookResponse.Attachments,
 		r.observedSecret,
 	)
+	// parse secret type
 	stype, found, err := unstructured.NestedString(
 		r.observedSecret.Object,
 		"type",
@@ -109,16 +119,17 @@ func (r *Reconciler) walkObservedSecret() {
 	if !found || stype == "" {
 		r.Warns = append(
 			r.Warns,
-			"Secret type not found in %q: Will use %q",
+			"Secret type not found: Name %q: Will default to %q",
 			r.observedSecretName,
-			SecretTypeBasicAuth,
+			types.SecretTypeBasicAuth,
 		)
 	}
-	if stype != SecretTypeBasicAuth {
+	// BasicAuth is the only supported secret
+	if stype != types.SecretTypeBasicAuth {
 		r.Err = errors.Errorf(
-			"Unsupported secret type %s: %q",
-			stype,
+			"Unsupported secret: Name %q: Type %q",
 			r.observedSecretName,
+			stype,
 		)
 		return
 	}
@@ -132,39 +143,52 @@ func (r *Reconciler) walkObservedSecret() {
 	}
 	if data == nil || !found {
 		r.Err = errors.Errorf(
-			"Secret data not found: %q",
+			"Secret data not found: Name %q",
 			r.observedSecretName,
 		)
 	}
-	r.observedUsername = fmt.Sprintf("%v", data[BasicAuthUsernameKey])
-	r.observedPassword = fmt.Sprintf("%v", data[BasicAuthPasswordKey])
+	// save the credentials to be used later
+	r.observedUsername = fmt.Sprintf("%v", data[types.BasicAuthUsernameKey])
+	r.observedPassword = fmt.Sprintf("%v", data[types.BasicAuthPasswordKey])
+	// validate presence of credentials
 	if r.observedUsername == "" || r.observedPassword == "" {
 		r.Err = errors.Errorf(
-			"Missing credentials in secret %q",
+			"Missing credentials in secret: Name %q",
 			r.observedSecretName,
 		)
 		return
 	}
 }
 
-func (r *Reconciler) invokeHTTP() {
-	req := resty.New().R().
-		SetBasicAuth(r.observedUsername, r.observedPassword).
-		SetBody(r.observedHTTP.Spec.Body).
-		SetHeaders(r.observedHTTP.Spec.Headers).
-		SetQueryParams(r.observedHTTP.Spec.QueryParams).
-		SetPathParams(r.observedHTTP.Spec.PathParams)
+func (r *Reconciler) skipReconcile() {
+	// HTTP resource does not have any attachments to be
+	// reconciled. Hence skip reconcile flag is set to true
+	r.HookResponse.SkipReconcile = true
+}
 
-	switch strings.ToLower(r.observedHTTP.Spec.Method) {
-	case types.POST:
-		r.response, r.Err = req.Post(r.observedHTTP.Spec.URL)
-	case types.GET:
-		r.response, r.Err = req.Get(r.observedHTTP.Spec.URL)
-	default:
-		r.Err = errors.Errorf(
-			"Unsupported http method %s",
-			r.observedHTTP.Spec.Method,
-		)
+func (r *Reconciler) invokeHTTP() {
+	i := http.Invoker(http.InvocableConfig{
+		Username:    r.observedUsername,
+		Password:    r.observedPassword,
+		HTTPMethod:  r.observedHTTP.Spec.Method,
+		URL:         r.observedHTTP.Spec.URL,
+		Body:        r.observedHTTP.Spec.Body,
+		Headers:     r.observedHTTP.Spec.Headers,
+		PathParams:  r.observedHTTP.Spec.PathParams,
+		QueryParams: r.observedHTTP.Spec.QueryParams,
+	})
+	r.response, r.Err = i.Invoke()
+}
+
+// handleRuntimeError handles runtime error if any
+func (r *Reconciler) handleRuntimeError() {
+	if r.Err == nil {
+		// nothing to do if there was no error
+		return
+	}
+	r.HookResponse.Status = map[string]interface{}{
+		"phase":  types.HTTPStatusPhaseError,
+		"reason": r.Err.Error(),
 	}
 }
 
@@ -173,16 +197,20 @@ func (r *Reconciler) invokeHTTP() {
 // of HTTP url.
 //
 // NOTE:
-//	This forms the core business logic of reconciling a HTTP
+//	Status forms the core business logic of reconciling a HTTP
 // custom resource.
 func (r *Reconciler) updateWatchStatus() {
-	var status = map[string]interface{}{}
-	var completion = map[string]interface{}{
-		"state": false,
+	// check for runtime errors
+	if r.Err != nil {
+		r.handleRuntimeError()
+		// skip setting other status fields
+		return
 	}
-	var warn string
-	// init with Online
-	status["phase"] = types.HTTPStatusPhaseOnline
+
+	// initialise phase to Online
+	var phase = types.HTTPStatusPhaseOnline
+	var warn, reason string
+
 	// check for warnings
 	if len(r.Warns) != 0 {
 		warn = fmt.Sprintf(
@@ -191,44 +219,38 @@ func (r *Reconciler) updateWatchStatus() {
 			strings.Join(r.Warns, ": "),
 		)
 	}
-	if warn != "" {
-		status["warn"] = warn
+
+	// check for error from response
+	if r.response.IsError {
+		phase = types.HTTPStatusPhaseError
 	}
-	// is runtime error
-	if r.Err != nil {
-		status["phase"] = types.HTTPStatusPhaseError
-		status["reason"] = r.Err.Error()
-	}
-	// set http response details
-	if r.response != nil {
-		status["body"] = r.response.Result()
-		status["httpStatusCode"] = r.response.StatusCode()
-		status["httpStatus"] = r.response.Status()
-		status["httpError"] = r.response.Error()
-	}
-	// check for error again & set/override the phase
-	if r.response != nil && r.response.IsError() {
-		status["phase"] = types.HTTPStatusPhaseError
-	}
-	// check for completion state
-	if r.Err == nil && r.response != nil && !r.response.IsError() {
-		completion["state"] = true
-	}
-	// set completion status
-	status["completion"] = completion
+
 	// set the desired status
-	r.HookResponse.Status = status
+	r.HookResponse.Status = map[string]interface{}{
+		"phase":  phase,
+		"reason": reason,
+		"warn":   warn,
+		"response": map[string]interface{}{
+			"body":           r.response.Body,
+			"httpStatusCode": r.response.HTTPStatusCode,
+			"httpStatus":     r.response.HTTPStatus,
+			"httpError":      r.response.HTTPError,
+			"isError":        r.response.IsError,
+		},
+	}
 }
 
-// Sync implements the idempotent logic to sync HTTP
+// Sync implements the idempotent logic to reconcile HTTP
+// custom resource.
 //
 // NOTE:
 // 	SyncHookRequest is the payload received as part of reconcile
 // request. Similarly, SyncHookResponse is the payload sent as a
-// response as part of reconcile request.
+// response.
 //
 // NOTE:
-//	This controller watches HTTP custom resource
+//	This controller watches HTTP custom resource. In other words,
+// HTTP custom resource is the watch.
 func Sync(request *generic.SyncHookRequest, response *generic.SyncHookResponse) error {
 	r := &Reconciler{
 		Reconciler: ctrlutil.Reconciler{
@@ -237,17 +259,27 @@ func Sync(request *generic.SyncHookRequest, response *generic.SyncHookResponse) 
 		},
 	}
 
-	// add functions to achieve desired state
+	// Add functions to achieve desired state by parsing
+	// the watch & attachments observed in the Kubernetes cluster
 	r.ReconcileFns = []func(){
-		r.walkObservedHTTP,
-		r.walkObservedSecret,
+		r.evalObservedHTTP,
+		r.evalObservedSecret,
+		r.skipReconcile,
 		r.invokeHTTP,
 	}
 
-	// add functions to achieve desired watch
+	// Add functions to update the watch
+	//
+	// NOTE:
+	//	One can add functions to set the watch's labels,
+	// annotations, & status.
+	//
+	// NOTE:
+	//	HTTP custom resource is the watch here
 	r.DesiredWatchFns = []func(){
 		r.updateWatchStatus,
 	}
+
 	// run reconcile
 	return r.Reconcile()
 }

--- a/deploy/operator.yaml
+++ b/deploy/operator.yaml
@@ -21,7 +21,7 @@ spec:
       serviceAccountName: dope
       containers:
       - name: dope
-        image: mayadataio/dope:v1.3.0 
+        image: mayadataio/dope:v1.3.0
         command: ["/usr/bin/dope"]
         args:
         - --logtostderr

--- a/go.mod
+++ b/go.mod
@@ -10,6 +10,7 @@ require (
 	github.com/magefile/mage v1.9.0
 	github.com/onsi/gomega v1.8.1
 	github.com/pkg/errors v0.9.1
+	gopkg.in/resty.v1 v1.12.0
 	k8s.io/apiextensions-apiserver v0.17.3
 	k8s.io/apimachinery v0.17.3
 	k8s.io/client-go v0.17.3

--- a/go.sum
+++ b/go.sum
@@ -440,6 +440,7 @@ gopkg.in/fsnotify.v1 v1.4.7/go.mod h1:Tz8NjZHkW78fSQdbUxIjBTcgA1z1m8ZHf0WmKUhAMy
 gopkg.in/inf.v0 v0.9.1 h1:73M5CoZyi3ZLMOyDlQh031Cx6N9NDJ2Vvfl76EDAgDc=
 gopkg.in/inf.v0 v0.9.1/go.mod h1:cWUDdTG/fYaXco+Dcufb5Vnc6Gp2YChqWtbxRZE0mXw=
 gopkg.in/natefinch/lumberjack.v2 v2.0.0/go.mod h1:l0ndWWf7gzL7RNwBG7wST/UCcT4T24xpD6X8LsfU/+k=
+gopkg.in/resty.v1 v1.12.0 h1:CuXP0Pjfw9rOuY6EP+UvtNvt5DSqHpIxILZKT/quCZI=
 gopkg.in/resty.v1 v1.12.0/go.mod h1:mDo4pnntr5jdWRML875a/NmxYqAlA73dVijT2AXvQQo=
 gopkg.in/square/go-jose.v2 v2.2.2/go.mod h1:M9dMgbHiYLoDGQrXy7OpJDJWiKiU//h+vD76mk0e1AI=
 gopkg.in/tomb.v1 v1.0.0-20141024135613-dd632973f1e7 h1:uRGJdciOHaEIrze2W8Q3AKkepLTh2hOroT7a+7czfdQ=

--- a/manifests/crd.yaml
+++ b/manifests/crd.yaml
@@ -11,7 +11,7 @@ spec:
     listKind: RecipeList
     plural: recipes
     shortNames:
-    - rp
+    - rcp
     singular: recipe
   scope: Namespaced
   subresources:

--- a/pkg/http/http.go
+++ b/pkg/http/http.go
@@ -1,0 +1,109 @@
+/*
+Copyright 2020 The MayaData Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    https://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package http
+
+import (
+	"strings"
+
+	resty "github.com/go-resty/resty/v2"
+	"github.com/pkg/errors"
+
+	types "mayadata.io/d-operators/types/http"
+)
+
+// InvocableConfig is used to initialise a new instance of
+// Invocable
+type InvocableConfig struct {
+	Username    string
+	Password    string
+	HTTPMethod  string
+	URL         string
+	Body        string
+	Headers     map[string]string
+	QueryParams map[string]string
+	PathParams  map[string]string
+}
+
+// Invocable helps invoking a http request
+type Invocable struct {
+	Username    string
+	Password    string
+	HTTPMethod  string
+	URL         string
+	Body        string
+	Headers     map[string]string
+	QueryParams map[string]string
+	PathParams  map[string]string
+}
+
+// Invoker returns a new instance of Invocable
+func Invoker(config InvocableConfig) *Invocable {
+	return &Invocable{
+		Username:    config.Username,
+		Password:    config.Password,
+		HTTPMethod:  config.HTTPMethod,
+		URL:         config.URL,
+		Body:        config.Body,
+		Headers:     config.Headers,
+		PathParams:  config.PathParams,
+		QueryParams: config.QueryParams,
+	}
+}
+
+func (i *Invocable) buildStatus(response *resty.Response) types.HTTPResponse {
+	var resp = &types.HTTPResponse{}
+	// set http response details
+	if response != nil {
+		resp.Body = response.Result()
+		resp.HTTPStatusCode = response.StatusCode()
+		resp.HTTPStatus = response.Status()
+		resp.HTTPError = response.Error()
+		resp.IsError = response.IsError()
+	}
+	return *resp
+}
+
+// Invoke executes the http request
+func (i *Invocable) Invoke() (types.HTTPResponse, error) {
+	req := resty.New().R().
+		SetBasicAuth(i.Username, i.Password).
+		SetBody(i.Body).
+		SetHeaders(i.Headers).
+		SetQueryParams(i.QueryParams).
+		SetPathParams(i.PathParams)
+
+	var response *resty.Response
+	var err error
+
+	switch strings.ToLower(i.HTTPMethod) {
+	case types.POST:
+		response, err = req.Post(i.URL)
+	case types.GET:
+		response, err = req.Get(i.URL)
+	default:
+		err = errors.Errorf(
+			"HTTP method not supported: URL %q: Method %q",
+			i.URL,
+			i.HTTPMethod,
+		)
+	}
+
+	if err != nil {
+		return types.HTTPResponse{}, err
+	}
+	return i.buildStatus(response), nil
+}

--- a/test/e2e/namespace.yaml
+++ b/test/e2e/namespace.yaml
@@ -1,0 +1,4 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: d-testing

--- a/test/e2e/registries.yaml
+++ b/test/e2e/registries.yaml
@@ -1,0 +1,4 @@
+mirrors:
+  docker.io:
+    endpoint:
+      - "http://localhost:5000"

--- a/test/e2e/suite.sh
+++ b/test/e2e/suite.sh
@@ -1,0 +1,158 @@
+#!/bin/bash
+
+cleanup() {
+  set +e
+
+  echo ""
+  echo "--------------------------"
+  echo "++ Clean up started"
+  echo "--------------------------"
+
+  echo -e "\n Display $ctrlbin-0 logs"
+  k3s kubectl logs -n $ctrlbin $ctrlbin-0
+
+  echo -e "\n Display status of experiment with name 'inference'"
+  k3s kubectl -n $ns get $group inference -ojson | jq .status || true
+
+  echo -e "\n Uninstall K3s"
+  /usr/local/bin/k3s-uninstall.sh > uninstall-k3s.txt 2>&1 || true
+
+  echo -e "\n Stop local docker registry container"
+  docker container stop e2eregistry || true
+
+  echo -e "\n Remove local docker registry container"
+  docker container rm -v e2eregistry || true
+  
+  echo ""
+  echo "--------------------------"
+  echo "++ Clean up completed"
+  echo "--------------------------"
+}
+
+# Comment below if you donot want to invoke cleanup 
+# after executing this script
+#
+# This is helpful if you might want to do some checks manually
+# & verify the state of the Kubernetes cluster and resources
+trap cleanup EXIT
+
+# Uncomment below if debug / verbose execution is needed
+#set -ex
+
+echo ""
+echo "--------------------------"
+echo "++ E to E suite started"
+echo "--------------------------"
+
+# Name of the Kubernetes controller binary under test
+ctrlbin="dope"
+
+# kind: Recipe custom resource is used to build the test cases
+group="recipes.dope.metacontroller.io"
+
+# Namespace used by all Recipe custom resources
+ns="d-testing"
+
+echo -e "\n Remove locally cached image $ctrlbin:e2e"
+docker image remove $ctrlbin:e2e || true
+
+echo -e "\n Remove locally cached image localhost:5000/$ctrlbin"
+docker image remove localhost:5000/$ctrlbin || true
+
+echo -e "\n Run local docker registry at port 5000"
+docker run -d -p 5000:5000 --restart=always --name e2eregistry registry:2
+
+echo -e "\n Build $ctrlbin image as $ctrlbin:e2e"
+docker build -t $ctrlbin:e2e ./../../
+
+echo -e "\n Tag $ctrlbin:e2e image as localhost:5000/$ctrlbin"
+docker tag $ctrlbin:e2e localhost:5000/$ctrlbin
+
+echo -e "\n Push the image to local registry running at localhost:5000"
+docker push localhost:5000/$ctrlbin
+
+echo -e "\n Setup K3s registries path"
+mkdir -p "/etc/rancher/k3s/"
+
+echo -e "\n Copy registries.yaml to K3s registries path"
+cp registries.yaml /etc/rancher/k3s/
+
+echo -e "\n Download K3s if not available"
+if true && k3s -v ; then
+    echo ""
+else
+    curl -sfL https://get.k3s.io | sh -
+fi
+
+echo -e "\n Verify if K3s is up and running"
+k3s kubectl get node
+
+echo -e "\n Apply $ctrlbin manifests to K3s cluster..."
+k3s kubectl apply -f ./../../manifests/
+
+echo -e "\n Apply $ctrlbin as a statefulset to K3s cluster..."
+cat <<EOF | k3s kubectl apply -f -
+apiVersion: apps/v1
+kind: StatefulSet
+metadata:
+  labels:
+    app.mayadata.io/name: dope
+  name: dope
+  namespace: dope
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app.mayadata.io/name: dope
+  serviceName: ""
+  template:
+    metadata:
+      labels:
+        app.mayadata.io/name: dope
+    spec:
+      serviceAccountName: dope
+      containers:
+      - name: dope
+        image: localhost:5000/dope
+        command: ["/usr/bin/dope"]
+        args:
+        - --logtostderr
+        - --run-as-local
+        - -v=1
+        - --discovery-interval=30s
+        - --cache-flush-interval=240s
+EOF
+
+echo -e "\n Apply test namespace to K3s cluster"
+k3s kubectl apply -f namespace.yaml
+
+echo -e "\n Apply test experiments to K3s cluster"
+k3s kubectl apply -f ./../experiments/
+
+echo -e "\n Retry 25 times until inference experiment gets executed"
+date
+phase=""
+for i in {1..25}
+do
+    phase=$(k3s kubectl -n $ns get $group inference -o=jsonpath='{.status.phase}')
+    echo -e "Attempt $i: Inference status: status.phase='$phase'"
+    if [[ "$phase" == "" ]]; then
+        sleep 5 # Sleep & retry since experiment is in-progress
+    else
+        break # Abandon this loop since phase is set
+    fi
+done
+date
+
+if [[ "$phase" != "Completed" ]]; then
+    echo ""
+    echo "--------------------------"
+    echo -e "++ E to E suite failed: status.phase='$phase'"
+    echo "--------------------------"
+    exit 1 # error since inference experiment did not succeed
+fi
+
+echo ""
+echo "--------------------------"
+echo "++ E to E suite passed"
+echo "--------------------------"

--- a/test/experiments/assert-job-teardown.yaml
+++ b/test/experiments/assert-job-teardown.yaml
@@ -1,19 +1,19 @@
 apiVersion: dope.metacontroller.io/v1
 kind: Recipe
 metadata:
-  name: assert-job-teardown
+  name: assert-recipe-teardown
   namespace: d-testing
   labels:
     d-testing.dope.metacontroller.io/enabled: "true"
 spec:
   tasks:
-  - name: create-a-job-with-teardown-enabled
+  - name: create-a-recipe-with-teardown-enabled
     create: 
       state: 
         kind: Recipe
         apiVersion: dope.metacontroller.io/v1
         metadata:
-          name: job-with-teardown-enabled
+          name: recipe-with-teardown-enabled
           namespace: d-testing
         spec:
           teardown: true # target under test
@@ -34,13 +34,13 @@ spec:
                 metadata:
                   name: i-get-auto-deleted
                   namespace: d-testing
-  - name: assert-completion-of-job
+  - name: assert-completion-of-recipe
     assert:
       state:
         kind: Recipe
         apiVersion: dope.metacontroller.io/v1
         metadata:
-          name: job-with-teardown-enabled
+          name: recipe-with-teardown-enabled
           namespace: d-testing
         status:
           phase: Completed

--- a/test/experiments/assert-lock-persists-for-job-that-runs-once.yaml
+++ b/test/experiments/assert-lock-persists-for-job-that-runs-once.yaml
@@ -1,19 +1,19 @@
 apiVersion: dope.metacontroller.io/v1
 kind: Recipe
 metadata:
-  name: assert-lock-persists-for-job-that-runs-once
+  name: assert-lock-persists-for-recipe-that-runs-once
   namespace: d-testing
   labels:
     d-testing.dope.metacontroller.io/enabled: "true"
 spec:
   tasks:
-  - name: create-a-job-that-runs-only-once
+  - name: create-a-recipe-that-runs-only-once
     create: 
       state: 
         kind: Recipe
         apiVersion: dope.metacontroller.io/v1
         metadata:
-          name: job-that-runs-only-once
+          name: recipe-that-runs-only-once
           namespace: d-testing
         spec:
           tasks:
@@ -24,13 +24,13 @@ spec:
                 apiVersion: v1
                 metadata:
                   name: d-testing
-  - name: assert-completion-of-job
+  - name: assert-completion-of-recipe
     assert:
       state:
         kind: Recipe
         apiVersion: dope.metacontroller.io/v1
         metadata:
-          name: job-that-runs-only-once
+          name: recipe-that-runs-only-once
           namespace: d-testing
         status:
           phase: Completed
@@ -40,6 +40,6 @@ spec:
         kind: ConfigMap
         apiVersion: v1
         metadata:
-          name: job-that-runs-only-once-lock
+          name: recipe-that-runs-only-once-lock
           namespace: d-testing
 ---

--- a/test/experiments/create-assert-fifty-configmaps-elapsedtime.yaml
+++ b/test/experiments/create-assert-fifty-configmaps-elapsedtime.yaml
@@ -24,7 +24,7 @@ metadata:
     d-testing.dope.metacontroller.io/enabled: "true"
 spec:
   tasks:
-  - name: assert-create-fifty-configmaps-job-completed
+  - name: assert-create-fifty-configmaps-recipe-completed
     assert: 
       state: 
         kind: Recipe
@@ -43,7 +43,7 @@ spec:
           name: create-fifty-configmaps
           namespace: d-testing
       pathCheck:
-        path: status.taskListStatus.job-elapsed-time.elapsedTimeInSeconds
+        path: status.taskListStatus.recipe-elapsed-time.elapsedTimeInSeconds
         pathCheckOperator: LTE
         # assert if the entire experiment of creating 50 configmaps
         # completes in around 20 seconds

--- a/test/experiments/inference.yaml
+++ b/test/experiments/inference.yaml
@@ -1,4 +1,4 @@
-# This is an internal job used by test suite runner
+# This is an internal recipe used by test suite runner
 # to evaluate if desired experiments were successful
 # or not
 apiVersion: dope.metacontroller.io/v1
@@ -20,7 +20,7 @@ spec:
         matchLabels:
           d-testing.dope.metacontroller.io/enabled: "true"
         matchLabelExpressions:
-        - key: job.dope.metacontroller.io/phase
+        - key: recipe.dope.metacontroller.io/phase
           operator: Exists
       when: ListCountEquals
       count: 6
@@ -34,7 +34,7 @@ spec:
           namespace: d-testing
           labels:
             d-testing.dope.metacontroller.io/enabled: "true"
-            job.dope.metacontroller.io/phase: Completed
+            recipe.dope.metacontroller.io/phase: Completed
       stateCheck:
         stateCheckOperator: ListCountEquals
         count: 6
@@ -47,7 +47,7 @@ spec:
           namespace: d-testing
           labels:
             d-testing.dope.metacontroller.io/enabled: "true"
-            job.dope.metacontroller.io/phase: Failed
+            recipe.dope.metacontroller.io/phase: Failed
       stateCheck:
         stateCheckOperator: ListCountEquals
         count: 0
@@ -60,7 +60,7 @@ spec:
           namespace: d-testing
           labels:
             d-testing.dope.metacontroller.io/enabled: "true"
-            job.dope.metacontroller.io/phase: Error
+            recipe.dope.metacontroller.io/phase: Error
       stateCheck:
         stateCheckOperator: ListCountEquals
         count: 0

--- a/types/gvk/gvk.go
+++ b/types/gvk/gvk.go
@@ -32,7 +32,7 @@ const (
 	KindRecipe string = "Recipe"
 
 	// APIVersionRecipe represent Recipe custom resource's api version
-	APIVersionRecipe string = "metacontroller.app/v1"
+	APIVersionRecipe string = "dope.metacontroller.io/v1"
 )
 
 const (

--- a/types/http/types.go
+++ b/types/http/types.go
@@ -21,12 +21,47 @@ import (
 )
 
 const (
+	// SecretTypeBasicAuth refers to basic authentication based secret
+	SecretTypeBasicAuth string = "kubernetes.io/basic-auth"
+
+	// BasicAuthUsernameKey is the key used to refer the username for
+	// SecretTypeBasicAuth secrets
+	BasicAuthUsernameKey = "username"
+
+	// BasicAuthPasswordKey is the key used to refer the password or
+	// token for SecretTypeBasicAuth secrets
+	BasicAuthPasswordKey = "password"
+)
+
+const (
 	// POST based http request
 	POST string = "post"
 
 	// GET based http request
 	GET string = "get"
 )
+
+// When is a typed definition to determine if HTTP custom resource
+// is enabled to be reconciled
+type When string
+
+const (
+	// Always flags the HTTP custom resource to be reconciled always
+	Always When = "always"
+
+	// Never disables the HTTP custom resource from being reconciled
+	Never When = "never"
+
+	// Once flags the HTTP custom resource to be reconciled only once
+	// This is useful to invoke http requests to create or delete entity
+	Once When = "once"
+)
+
+// Enabled determines if HTTP custom resource is enabled to be
+// reconciled
+type Enabled struct {
+	When When `json:"when,omitempty"`
+}
 
 // HTTP is a kubernetes custom resource that defines
 // the specifications to invoke http request & store its
@@ -42,26 +77,55 @@ type HTTP struct {
 // HTTPRequestSpec defines the configuration required
 // to invoke http request
 type HTTPRequestSpec struct {
-	SecretName  string            `json:"secretName"`
-	URL         string            `json:"url"`
-	Method      string            `json:"method,omitempty"`
-	Headers     map[string]string `json:"headers,omitempty"`
+	// Enabled flags this custom resource as enabled or disabled
+	// for reconciliation
+	Enabled *Enabled `json:"enabled,omitempty"`
+
+	// Kubernetes secret to authorise the HTTP request
+	SecretName string `json:"secretName"`
+
+	// URL to be invoked
+	URL string `json:"url"`
+
+	// Post or Get call
+	Method string `json:"method,omitempty"`
+
+	// Headers used during API invocation
+	Headers map[string]string `json:"headers,omitempty"`
+
+	// QueryParams set against the URL query parameters
 	QueryParams map[string]string `json:"queryParams,omitempty"`
-	PathParams  map[string]string `json:"pathParams,omitempty"`
-	Body        string            `json:"body,omitempty"`
+
+	// PathParams set against the URL path
+	PathParams map[string]string `json:"pathParams,omitempty"`
+
+	// HTTP body used during API invocation
+	Body string `json:"body,omitempty"`
 }
 
 // HTTPRequestStatus has the status & response of an
 // invoked http URL
 type HTTPRequestStatus struct {
-	Phase          string                 `json:"phase"`
-	Reason         string                 `json:"reason"`
-	Warn           string                 `json:"warn"`
-	Completion     map[string]interface{} `json:"completion"`
-	Body           interface{}            `json:"body"`
-	HTTPStatusCode int                    `json:"httpStatusCode"`
-	HTTPStatus     string                 `json:"httpStatus"`
-	HTTPError      interface{}            `json:"httpError"`
+	// Phase represents a single word status of http invocation
+	Phase string `json:"phase"`
+
+	// Reason reflects a decription of what happened after http invocation
+	Reason string `json:"reason,omitempty"`
+
+	// Warning message(s) if any
+	Warn string `json:"warn,omitempty"`
+
+	// Response received after invoking http request
+	Response HTTPResponse `json:"response,omitempty"`
+}
+
+// HTTPResponse represents the response received after invoking http request
+type HTTPResponse struct {
+	Body           interface{} `json:"body,omitempty"`
+	HTTPStatusCode int         `json:"httpStatusCode"`
+	HTTPStatus     string      `json:"httpStatus"`
+	HTTPError      interface{} `json:"httpError,omitempty"`
+	IsError        bool        `json:"isError"`
 }
 
 const (

--- a/types/recipe/task.go
+++ b/types/recipe/task.go
@@ -47,10 +47,10 @@ type FailFast struct {
 	When FailFastRule `json:"when,omitempty"`
 }
 
-// Task that needs to be executed as part of a Job
+// Task that needs to be executed as part of a Recipe
 //
 // Task forms the fundamental unit of execution within a
-// Job
+// Recipe
 type Task struct {
 	Name            string          `json:"name"`
 	Assert          *Assert         `json:"assert,omitempty"`


### PR DESCRIPTION
This commit has changes that fixes the manifests & code that were
still referring to old job custom resource.

In addition, this commit provides a way to trigger E to E testing
as a make target. This has also been added to github actions to
proactively verify any errors injected by changes during the review
phase itself.

E to E testing make use of local docker registry and K3s to test
D-operators' controllers.

README has been updated to highlight that fact that D-operators uses
itself to perform end to end tests on its controllers. In other words
Recipe custom resource is used to test Recipe & other resources.

Signed-off-by: AmitKumarDas <amit.das@mayadata.io>