### PR TITLE
feat(http): add http as a custom resource

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,5 @@ d-operators
 test/bin/
 test/kubebin/
 test/e2e/uninstall-k3s.txt
+uninstall-k3s.txt
+dope

--- a/Makefile
+++ b/Makefile
@@ -1,13 +1,8 @@
-PWD := ${CURDIR}
-
-OS = $(shell uname)
-
-PACKAGE_VERSION ?= $(shell git describe --always --tags)
-GIT_TAGS = $(shell git fetch --all --tags)
+# Fetch the latest tags & then set the package version
+PACKAGE_VERSION ?= $(shell git fetch --all --tags | echo "" | git describe --always --tags)
 ALL_SRC = $(shell find . -name "*.go" | grep -v -e "vendor")
 
 # We are using docker hub as the default registry
-#IMG_REGISTRY ?= quay.io
 IMG_NAME ?= dope
 IMG_REPO ?= mayadataio/dope
 
@@ -21,8 +16,6 @@ $(IMG_NAME): $(ALL_SRC)
 		go build -o $@ ./cmd/main.go
 
 $(ALL_SRC): ;
-
-$(GIT_TAGS): ;
 
 # go mod download modules to local cache
 # make vendored copy of dependencies
@@ -46,9 +39,9 @@ e2e-test:
 	@cd test/e2e && ./suite.sh
 
 .PHONY: image
-image: $(GIT_TAGS)
+image:
 	docker build -t $(IMG_REPO):$(PACKAGE_VERSION) .
 
 .PHONY: push
 push: image
-	docker push $(IMG_REPO):$(PACKAGE_VERSION
+	docker push $(IMG_REPO):$(PACKAGE_VERSION)

--- a/config/metac.yaml
+++ b/config/metac.yaml
@@ -1,14 +1,30 @@
-apiVersion: metac.openebs.io/v1alpha1
+apiVersion: dope/v1
 kind: GenericController
 metadata:
   name: sync-recipe
   namespace: dope
 spec:
-  watch: # kind: Recipe custom resource is watched
+  watch: 
+    # kind: Recipe custom resource is watched
     apiVersion: dope.metacontroller.io/v1
     resource: recipes
   hooks:
     sync:
       inline:
         funcName: sync/recipe
+---
+apiVersion: dope/v1
+kind: GenericController
+metadata:
+  name: sync-http
+  namespace: dope
+spec:
+  watch: 
+    # kind: HTTP custom resource is watched
+    apiVersion: dope.metacontroller.io/v1
+    resource: https
+  hooks:
+    sync:
+      inline:
+        funcName: sync/http
 ---

--- a/controller/recipe/reconciler.go
+++ b/controller/recipe/reconciler.go
@@ -74,7 +74,7 @@ func (r *Reconciler) setSyncResponse() {
 	}
 }
 
-func (r *Reconciler) setWatchStatusAsError() {
+func (r *Reconciler) setRecipeStatusAsError() {
 	r.HookResponse.Status = map[string]interface{}{
 		"phase":  "Error",
 		"reason": r.Err.Error(),
@@ -84,7 +84,7 @@ func (r *Reconciler) setWatchStatusAsError() {
 	}
 }
 
-func (r *Reconciler) setWatchStatusFromRecipeStatus() {
+func (r *Reconciler) setRecipeStatus() {
 	r.HookResponse.Status = map[string]interface{}{
 		"phase":           string(r.RecipeStatus.Phase),
 		"reason":          r.RecipeStatus.Reason,
@@ -110,7 +110,7 @@ func (r *Reconciler) setWatchStatus() {
 			r.HookResponse.ResyncAfterSeconds =
 				*r.ObservedRecipe.Spec.Refresh.OnErrorResyncAfterSeconds
 		}
-		r.setWatchStatusAsError()
+		r.setRecipeStatusAsError()
 		return
 	}
 	if r.RecipeStatus.Phase == types.RecipeStatusLocked {
@@ -118,7 +118,7 @@ func (r *Reconciler) setWatchStatus() {
 		// old status will persist
 		return
 	}
-	r.setWatchStatusFromRecipeStatus()
+	r.setRecipeStatus()
 }
 
 // Sync implements the idempotent logic to sync Recipe resource

--- a/manifests/crd.yaml
+++ b/manifests/crd.yaml
@@ -21,3 +21,26 @@ spec:
   - name: v1
     served: true
     storage: true
+---
+apiVersion: apiextensions.k8s.io/v1beta1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+  name: https.dope.metacontroller.io
+spec:
+  group: dope.metacontroller.io
+  names:
+    kind: HTTP
+    listKind: HTTPList
+    plural: https
+    shortNames:
+    - http
+    singular: http
+  scope: Namespaced
+  subresources:
+    status: {}
+  version: v1
+  versions:
+  - name: v1
+    served: true
+    storage: true

--- a/pkg/http/http.go
+++ b/pkg/http/http.go
@@ -80,16 +80,20 @@ func (i *Invocable) buildStatus(response *resty.Response) types.HTTPResponse {
 // Invoke executes the http request
 func (i *Invocable) Invoke() (types.HTTPResponse, error) {
 	req := resty.New().R().
-		SetBasicAuth(i.Username, i.Password).
 		SetBody(i.Body).
 		SetHeaders(i.Headers).
 		SetQueryParams(i.QueryParams).
 		SetPathParams(i.PathParams)
 
+	// set credentials only if it was provided
+	if i.Username != "" || i.Password != "" {
+		req.SetBasicAuth(i.Username, i.Password)
+	}
+
 	var response *resty.Response
 	var err error
 
-	switch strings.ToLower(i.HTTPMethod) {
+	switch strings.ToUpper(i.HTTPMethod) {
 	case types.POST:
 		response, err = req.Post(i.URL)
 	case types.GET:

--- a/pkg/recipe/recipe_test.go
+++ b/pkg/recipe/recipe_test.go
@@ -322,8 +322,8 @@ func TestRunnerRunAllTasks(t *testing.T) {
 				},
 				fixture: f,
 			}
-			r.initEnabled()        // init to avoid nil pointers
-			got, err := r.runAll() // method under test
+			r.initEnabled()             // init to avoid nil pointers
+			got, err := r.runAllTasks() // method under test
 			if mock.isErr && err == nil {
 				t.Fatal("Expected error got none")
 			}

--- a/test/e2e/ci.yaml
+++ b/test/e2e/ci.yaml
@@ -1,8 +1,8 @@
 # This yaml file demonstrates the use of Kubernetes
 # and few custom resources to build a custom CI 
-# infrastructure. In this infrastructure, Kubernetes 
-# is the CI runner and custom resources are the test 
-# cases.
+# framework. In this framework, Kubernetes is the CI
+# runner and custom resources are the test case 
+# implementations.
 --- 
 # d-testing is the Kubernetes namespace that can
 # be used to deploy any test artifacts
@@ -34,6 +34,31 @@ spec:
     shortNames:
     - rcp
     singular: recipe
+  scope: Namespaced
+  subresources:
+    status: {}
+  version: v1
+  versions:
+  - name: v1
+    served: true
+    storage: true
+---
+# HTTP custom resource is used to invoke http request
+# in a declarative way
+apiVersion: apiextensions.k8s.io/v1beta1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+  name: https.dope.metacontroller.io
+spec:
+  group: dope.metacontroller.io
+  names:
+    kind: HTTP
+    listKind: HTTPList
+    plural: https
+    shortNames:
+    - http
+    singular: http
   scope: Namespaced
   subresources:
     status: {}
@@ -86,7 +111,7 @@ metadata:
   name: dope
   namespace: dope
 spec:
-  replicas: 1
+  replicas: 1 # higher value helps in executing experiments faster
   selector:
     matchLabels:
       app.mayadata.io/name: dope
@@ -99,7 +124,8 @@ spec:
       serviceAccountName: dope
       containers:
       - name: dope
-        # this may be replaced by a stable release tag
+        # image may be replaced by a stable release tag
+        # e.g. mayadataio/dope:latest
         #
         # Since dope itself is the target under test, this
         # ci.yaml uses the master build available in the local
@@ -109,6 +135,7 @@ spec:
         args:
         - --logtostderr
         - --run-as-local
-        - -v=1
+        - -v=1 # increasing level will make the ci logs verbose
+        - --workers-count=20 # higher value helps in executing experiments faster
         - --discovery-interval=30s
         - --cache-flush-interval=240s

--- a/test/e2e/inference.yaml
+++ b/test/e2e/inference.yaml
@@ -1,31 +1,56 @@
 # This is an internal recipe used by test suite runner
-# to evaluate if desired experiments were successful
-# or not
+# to evaluate if desired experiments (read Recipes) were
+# successful or not
+#
+# NOTE:
+#   This Recipe evaluates number of successful, failed &
+# errored Recipes
 apiVersion: dope.metacontroller.io/v1
 kind: Recipe
 metadata:
-  # should match setup.yaml 
-  name: inference # matches spec.test.inference.experimentName
-  namespace: d-testing # matches spec.test.inference.experimentNamespace
+  name: inference
+  namespace: d-testing
   labels:
     d-testing.dope.metacontroller.io/internal: "true"
 spec:
-  # delay start of execution by 30 seconds
-  thinkTimeInSeconds: 30.0001
-  # this experiment is enabled only after all other desired experiments
-  # are executed & are set with status.phase
+  # This will delay the start of execution of this Recipe based
+  # on the specified time
+  #
+  # NOTE:
+  #   This think time should be sufficient to let all 
+  # experiments (read Recipes used as test cases) get executed
+  #
+  # NOTE:
+  #   In other words, we want this Recipe to execute its tasks
+  # after waiting for the specified time
+  #
+  # NOTE:
+  #   This also implies that CI will definitely take this much 
+  # time to decide the result of the CI run
+  thinkTimeInSeconds: 20.0001
+  # This Recipe is eligible to run only when the checks succeed
+  #
+  # NOTE:
+  #   In this case, this Recipe will be eligible only after the
+  # number of Recipes with matching labels equal the given count
+  #
+  # NOTE:
+  #   Eligibility check will get triggered after above think time 
+  # has elapsed
   eligible:
     checks:
     - labelSelector:
         matchLabels:
-          d-testing.dope.metacontroller.io/enabled: "true"
+          d-testing.dope.metacontroller.io/inference: "true"
         matchLabelExpressions:
         - key: recipe.dope.metacontroller.io/phase
           operator: Exists
       when: ListCountEquals
-      count: 6
+      count: 10
   tasks:
-  - name: assert-all-tests-are-completed
+  # Start with asserting the count of Recipes that should 
+  # complete successfully
+  - name: assert-count-of-tests-that-completed
     assert: 
       state: 
         kind: Recipe
@@ -33,12 +58,14 @@ spec:
         metadata:
           namespace: d-testing
           labels:
-            d-testing.dope.metacontroller.io/enabled: "true"
+            d-testing.dope.metacontroller.io/inference: "true"
             recipe.dope.metacontroller.io/phase: Completed
       stateCheck:
         stateCheckOperator: ListCountEquals
-        count: 6
-  - name: assert-no-tests-have-failed
+        # These many Recipes should succeed
+        count: 8
+  # Then assert the count of Recipes that should fail
+  - name: assert-count-of-tests-that-failed
     assert: 
       state: 
         kind: Recipe
@@ -46,12 +73,14 @@ spec:
         metadata:
           namespace: d-testing
           labels:
-            d-testing.dope.metacontroller.io/enabled: "true"
+            d-testing.dope.metacontroller.io/inference: "true"
             recipe.dope.metacontroller.io/phase: Failed
       stateCheck:
         stateCheckOperator: ListCountEquals
-        count: 0
-  - name: assert-no-tests-have-errored
+        # These many Recipes should fail
+        count: 2
+  # Then assert the count of Recipes that should error
+  - name: assert-count-of-tests-that-errored
     assert: 
       state: 
         kind: Recipe
@@ -59,9 +88,10 @@ spec:
         metadata:
           namespace: d-testing
           labels:
-            d-testing.dope.metacontroller.io/enabled: "true"
+            d-testing.dope.metacontroller.io/inference: "true"
             recipe.dope.metacontroller.io/phase: Error
       stateCheck:
         stateCheckOperator: ListCountEquals
+        # These many Recipes should error out
         count: 0
 ---

--- a/test/e2e/suite.sh
+++ b/test/e2e/suite.sh
@@ -8,12 +8,6 @@ cleanup() {
   echo "++ Clean up started"
   echo "--------------------------"
 
-  echo -e "\n Display $ctrlbin-0 logs"
-  k3s kubectl logs -n $ctrlbin $ctrlbin-0
-
-  echo -e "\n Display status of experiment with name 'inference'"
-  k3s kubectl -n $ns get $group inference -ojson | jq .status || true
-
   echo -e "\n Uninstall K3s"
   /usr/local/bin/k3s-uninstall.sh > uninstall-k3s.txt 2>&1 || true
 
@@ -90,11 +84,11 @@ k3s kubectl get node
 echo -e "\n Apply d-operators based ci to K3s cluster"
 k3s kubectl apply -f ci.yaml
 
-echo -e "\n Apply ci inference to K3s cluster"
-k3s kubectl apply -f inference.yaml
-
 echo -e "\n Apply test experiments to K3s cluster"
 k3s kubectl apply -f ./../experiments/
+
+echo -e "\n Apply ci inference to K3s cluster"
+k3s kubectl apply -f inference.yaml
 
 echo -e "\n Retry 25 times until inference experiment gets executed"
 date
@@ -110,6 +104,12 @@ do
     fi
 done
 date
+
+echo -e "\n Display $ctrlbin-0 logs"
+k3s kubectl logs -n $ctrlbin $ctrlbin-0
+
+echo -e "\n Display status of experiment with name 'inference'"
+k3s kubectl -n $ns get $group inference -ojson | jq .status || true
 
 if [[ "$phase" != "Completed" ]]; then
     echo ""

--- a/test/experiments/assert-deprecated-daemonset.yaml
+++ b/test/experiments/assert-deprecated-daemonset.yaml
@@ -4,7 +4,7 @@ metadata:
   name: assert-absence-of-deprecated-daemonsets
   namespace: d-testing
   labels:
-    d-testing.dope.metacontroller.io/enabled: "true"
+    d-testing.dope.metacontroller.io/inference: "true"
 spec:
   tasks:
   - name: assert-daemonset-with-extensions-v1beta1

--- a/test/experiments/assert-github-search-invalid-method-negative.yaml
+++ b/test/experiments/assert-github-search-invalid-method-negative.yaml
@@ -1,0 +1,39 @@
+apiVersion: dope.metacontroller.io/v1
+kind: Recipe
+metadata:
+  name: assert-github-search-with-invalid-method-neg
+  namespace: d-testing
+  labels:
+    d-testing.dope.metacontroller.io/inference: "true"
+spec:
+  tasks:
+  # Start by applying this HTTP resource
+  - name: apply-github-search-with-invalid-method-neg
+    apply: 
+      state: 
+        apiVersion: dope.metacontroller.io/v1
+        kind: HTTP
+        metadata:
+          name: github-search-with-invalid-method-neg
+          namespace: d-testing
+        spec:
+          url: https://github.com/search
+          # This is an invalid value
+          method: GETT
+  # Then assert status of this HTTP resource
+  - name: assert-github-search-with-invalid-method-neg
+    assert: 
+      state: 
+        apiVersion: dope.metacontroller.io/v1
+        kind: HTTP
+        metadata:
+          name: github-search-with-invalid-method-neg
+          namespace: d-testing
+        status:
+          # Phase of this HTTP resource will never be Completed
+          # It will have Error instead
+          #
+          # This is a negative test case
+          # In other words this Recipe will Fail
+          phase: Completed
+---

--- a/test/experiments/assert-github-search-invalid-method.yaml
+++ b/test/experiments/assert-github-search-invalid-method.yaml
@@ -1,0 +1,40 @@
+apiVersion: dope.metacontroller.io/v1
+kind: Recipe
+metadata:
+  name: assert-github-search-with-invalid-method
+  namespace: d-testing
+  labels:
+    d-testing.dope.metacontroller.io/inference: "true"
+spec:
+  tasks:
+  # Start by applying this HTTP custom resource
+  - name: apply-github-search-with-invalid-method
+    apply: 
+      state: 
+        apiVersion: dope.metacontroller.io/v1
+        kind: HTTP
+        metadata:
+          name: github-search-with-invalid-method
+          namespace: d-testing
+        spec:
+          url: https://github.com/search
+          # Method is set to an invalid value
+          method: GETT
+  # Then assert this HTTP resource
+  - name: assert-github-search-with-invalid-method
+    assert: 
+      state: 
+        apiVersion: dope.metacontroller.io/v1
+        kind: HTTP
+        metadata:
+          name: github-search-with-invalid-method
+          namespace: d-testing
+        status:
+          # This HTTP resource is expected to Error
+          # since its method is set to an invalid value
+          #
+          # NOTE:
+          #   The Recipe will complete successfully since
+          # this assertion is correct
+          phase: Error
+---

--- a/test/experiments/assert-github-search-neg.yaml
+++ b/test/experiments/assert-github-search-neg.yaml
@@ -1,0 +1,47 @@
+apiVersion: dope.metacontroller.io/v1
+kind: Recipe
+metadata:
+  name: assert-github-search-neg
+  namespace: d-testing
+  labels:
+    d-testing.dope.metacontroller.io/inference: "true"
+spec:
+  tasks:
+  # Start by applying this HTTP custom resource
+  #
+  # NOTE:
+  #   Once this resource is applied against the Kubernetes
+  # cluster, it starts invoking the http request specified
+  # in its spec. Resulting output is set against its status.
+  - name: apply-github-search-neg
+    apply: 
+      state: 
+        apiVersion: dope.metacontroller.io/v1
+        kind: HTTP
+        metadata:
+          name: github-search-neg
+          namespace: d-testing
+        spec:
+          url: https://github.com/search
+          # This method is invalid
+          method: GETT
+  # Then assert this HTTP resource to have completed
+  # successfully
+  - name: assert-github-search-neg
+    assert: 
+      state: 
+        apiVersion: dope.metacontroller.io/v1
+        kind: HTTP
+        metadata:
+          name: github-search-neg
+          namespace: d-testing
+        status:
+          # If HTTP resource completes successfully then
+          # phase should be set to Completed
+          #
+          # NOTE:
+          #   However, this HTTP resource will not succeed due
+          # to invalid http method. Hence, this assertion must
+          # fail resulting in failure of this Recipe.
+          phase: Online
+---

--- a/test/experiments/assert-github-search.yaml
+++ b/test/experiments/assert-github-search.yaml
@@ -1,0 +1,41 @@
+apiVersion: dope.metacontroller.io/v1
+kind: Recipe
+metadata:
+  name: assert-github-search
+  namespace: d-testing
+  labels:
+    d-testing.dope.metacontroller.io/inference: "true"
+spec:
+  tasks:
+  # Start by applying this HTTP custom resource
+  #
+  # NOTE:
+  #   Once this resource is applied against the Kubernetes
+  # cluster, it starts invoking the http request specified
+  # in its spec. Resulting output is set against its status.
+  - name: apply-github-search
+    apply: 
+      state: 
+        apiVersion: dope.metacontroller.io/v1
+        kind: HTTP
+        metadata:
+          name: github-search
+          namespace: d-testing
+        spec:
+          url: https://github.com/search
+          method: GET
+  # Then assert this HTTP resource to have completed
+  # successfully
+  - name: assert-github-search
+    assert: 
+      state: 
+        apiVersion: dope.metacontroller.io/v1
+        kind: HTTP
+        metadata:
+          name: github-search
+          namespace: d-testing
+        status:
+          # If HTTP resource completes successfully then
+          # phase should be set to Completed
+          phase: Online
+---

--- a/test/experiments/assert-job-teardown.yaml
+++ b/test/experiments/assert-job-teardown.yaml
@@ -4,7 +4,7 @@ metadata:
   name: assert-recipe-teardown
   namespace: d-testing
   labels:
-    d-testing.dope.metacontroller.io/enabled: "true"
+    d-testing.dope.metacontroller.io/inference: "true"
 spec:
   tasks:
   - name: create-a-recipe-with-teardown-enabled

--- a/test/experiments/assert-lock-persists-for-job-that-runs-once.yaml
+++ b/test/experiments/assert-lock-persists-for-job-that-runs-once.yaml
@@ -4,7 +4,7 @@ metadata:
   name: assert-lock-persists-for-recipe-that-runs-once
   namespace: d-testing
   labels:
-    d-testing.dope.metacontroller.io/enabled: "true"
+    d-testing.dope.metacontroller.io/inference: "true"
 spec:
   tasks:
   - name: create-a-recipe-that-runs-only-once

--- a/test/experiments/create-assert-fifty-configmaps-elapsedtime.yaml
+++ b/test/experiments/create-assert-fifty-configmaps-elapsedtime.yaml
@@ -1,52 +1,101 @@
 apiVersion: dope.metacontroller.io/v1
 kind: Recipe
 metadata:
-  name: create-fifty-configmaps
+  name: create-fifty-configmaps-in-time
   namespace: d-testing
+  labels:
+    i-create-50-configs: "true"
+    i-am-tested-if-creation-of-configs-happen-in-time: "true"
 spec:
   tasks:
+  # This task creates 50 config maps
+  # The names of these config maps are suffixed
+  # with numbers 
+  #
+  # NOTE:
+  #   Following config maps will get created:
+  # - create-cm-in-time-0,
+  # - create-cm-in-time-1,
+  # ...
+  # - create-cm-in-time-48,
+  # - create-cm-in-time-49
+  #
+  # NOTE:
+  #   Task will error out if any of these config maps
+  # already exist in the cluster
   - name: create-fifty-configmaps
     create: 
       state: 
         kind: ConfigMap
         apiVersion: v1
         metadata:
-          name: create-cm-elapsed-time
+          name: create-cm-in-time
           namespace: d-testing
       replicas: 50
 ---
 apiVersion: dope.metacontroller.io/v1
 kind: Recipe
 metadata:
-  name: assert-creation-of-fifty-configmaps-elapsed-time
+  name: assert-creation-of-fifty-configmaps-in-time
   namespace: d-testing
   labels:
-    d-testing.dope.metacontroller.io/enabled: "true"
+    d-testing.dope.metacontroller.io/inference: "true"
 spec:
+  # This will delay the start of execution of this Recipe based
+  # on the specified time
+  #
+  # NOTE:
+  #   This think time should be sufficient to let all 
+  # experiments (read Recipes used as test cases) get executed
+  #
+  # NOTE:
+  #   In other words, we want this Recipe to execute its tasks
+  # after waiting for the specified time
+  thinkTimeInSeconds: 10.0001
+  # This Recipe is eligible to run only when the checks succeed
+  #
+  # NOTE:
+  #   In this case, this Recipe will be eligible only after the
+  # number of Recipes with matching labels equal the given count
+  #
+  # NOTE:
+  #   Eligibility check will get triggered after above think time 
+  # has elapsed
+  eligible:
+    checks:
+    - labelSelector:
+        matchLabels:
+          i-create-50-configs: "true"
+          i-am-tested-if-creation-of-configs-happen-in-time: "true"
+        matchLabelExpressions:
+        - key: recipe.dope.metacontroller.io/phase
+          operator: Exists
+      when: ListCountEquals
+      count: 1
   tasks:
-  - name: assert-create-fifty-configmaps-recipe-completed
+  - name: assert-completion-of-fifty-configmaps-recipe
     assert: 
       state: 
         kind: Recipe
         apiVersion: dope.metacontroller.io/v1
         metadata:
-          name: create-fifty-configmaps
+          name: create-fifty-configmaps-in-time
           namespace: d-testing
         status:
           phase: Completed
-  - name: assert-creation-of-fifty-configmaps-within-time
+  - name: assert-creation-of-fifty-configmaps-in-time
     assert: 
       state: 
         kind: Recipe
         apiVersion: dope.metacontroller.io/v1
         metadata:
-          name: create-fifty-configmaps
+          name: create-fifty-configmaps-in-time
           namespace: d-testing
       pathCheck:
         path: status.taskListStatus.recipe-elapsed-time.elapsedTimeInSeconds
         pathCheckOperator: LTE
-        # assert if the entire experiment of creating 50 configmaps
-        # completes in around 20 seconds
+        # assert if the recipe to create 50 configmaps
+        # completes within 20 seconds
         value: 20.0001
         dataType: float64
 ---

--- a/test/experiments/create-assert-fifty-configmaps.yaml
+++ b/test/experiments/create-assert-fifty-configmaps.yaml
@@ -1,10 +1,10 @@
 apiVersion: dope.metacontroller.io/v1
 kind: Recipe
 metadata:
-  name: create-assert-fifty-configmaps
+  name: create-and-assert-fifty-configmaps
   namespace: d-testing
   labels:
-    d-testing.dope.metacontroller.io/enabled: "true"
+    d-testing.dope.metacontroller.io/inference: "true"
 spec:
   tasks:
   - name: create-fifty-configmaps

--- a/test/experiments/crud-ops-on-pod.yaml
+++ b/test/experiments/crud-ops-on-pod.yaml
@@ -4,7 +4,7 @@ metadata:
   name: crud-ops-on-pod
   namespace: d-testing
   labels:
-    d-testing.dope.metacontroller.io/enabled: "true"
+    d-testing.dope.metacontroller.io/inference: "true"
 spec:
   tasks:
   - name: apply-a-namespace

--- a/types/http/types.go
+++ b/types/http/types.go
@@ -35,10 +35,10 @@ const (
 
 const (
 	// POST based http request
-	POST string = "post"
+	POST string = "POST"
 
 	// GET based http request
-	GET string = "get"
+	GET string = "GET"
 )
 
 // When is a typed definition to determine if HTTP custom resource
@@ -47,14 +47,14 @@ type When string
 
 const (
 	// Always flags the HTTP custom resource to be reconciled always
-	Always When = "always"
+	Always When = "Always"
 
 	// Never disables the HTTP custom resource from being reconciled
-	Never When = "never"
+	Never When = "Never"
 
 	// Once flags the HTTP custom resource to be reconciled only once
 	// This is useful to invoke http requests to create or delete entity
-	Once When = "once"
+	Once When = "Once"
 )
 
 // Enabled determines if HTTP custom resource is enabled to be

--- a/types/recipe/state_check.go
+++ b/types/recipe/state_check.go
@@ -84,9 +84,18 @@ func (phase StateCheckResultPhase) ToAssertResultPhase() AssertStatusPhase {
 
 // StateCheckResult holds the result of StateCheck operation
 type StateCheckResult struct {
-	Phase   StateCheckResultPhase `json:"phase"`
-	Message string                `json:"message,omitempty"`
-	Verbose string                `json:"verbose,omitempty"`
-	Warning string                `json:"warning,omitempty"`
-	Timeout string                `json:"timeout,omitempty"`
+	// status as a pre-defined key word
+	Phase StateCheckResultPhase `json:"phase"`
+
+	// short message
+	Message string `json:"message,omitempty"`
+
+	// detailed message
+	Verbose string `json:"verbose,omitempty"`
+
+	// warning details
+	Warning string `json:"warning,omitempty"`
+
+	// timeout details
+	Timeout string `json:"timeout,omitempty"`
 }


### PR DESCRIPTION
This commit adds HTTP as a custom resource. This can currently
be used to invoke http requests that do not need any
authentication. Few e2e experiments added to verify HTTP custom
resource.

This change also includes a minor bug fix w.r.t StateCheck assert
action. Before this fix any timeout error resulted in Recipe's
status.phase being set as 'Error'. With current changes any timeout
error will result in Recipe's status.phase as 'Failed'.

In addition, ci related artifacts including experiments & yaml
comments have been updated to make the ci run faster as well as
make it more readable for contributors.

Signed-off-by: AmitKumarDas <amit.das@mayadata.io>