### PR TITLE
chore(validation): add schema validation for field paths

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,52 @@
 ## D-operators
-D-operators define various declarative patterns to write kubernetes controllers. This uses [metac](https://github.com/AmitKumarDas/metac/) under the hood. Users can _create_, _delete_, _update_, _assert_, _patch_, _clone_, & _schedule_ one or more kubernetes resources _(native as well as custom)_ using a yaml file. D-operators expose a bunch of kubernetes custom resources that provide the building blocks to implement a higher order controller.
+D-operators define various declarative patterns to write kubernetes controllers. This uses [metac](https://github.com/AmitKumarDas/metac/) under the hood. Users can _create_, _delete_, _update_, _assert_, _patch_, _clone_, & _schedule_ one or more kubernetes resources _(native as well as custom)_ using a yaml file. D-operators expose a bunch of kubernetes custom resources that provide the building blocks to implement higher order controller(s).
 
 D-operators follow a pure intent based approach to writing specifications **instead of** having to deal with yamls that are cluttered with scripts, kubectl, loops, conditions, templating and so on.
+
+### A sample declarative intent
+```yaml
+apiVersion: dope.mayadata.io/v1
+kind: Recipe
+metadata:
+  name: crud-ops-on-pod
+  namespace: d-testing
+spec:
+  tasks:
+  - name: apply-a-namespace
+    apply: 
+      state: 
+        kind: Namespace
+        apiVersion: v1
+        metadata:
+          name: my-ns
+  - name: create-a-pod
+    create: 
+      state: 
+        kind: Pod
+        apiVersion: v1
+        metadata:
+          name: my-pod
+          namespace: my-ns
+        spec:
+          containers:
+          - name: web
+            image: nginx
+  - name: delete-the-pod
+    delete: 
+      state: 
+        kind: Pod
+        apiVersion: v1
+        metadata:
+          name: my-pod
+          namespace: my-ns
+  - name: delete-the-namespace
+    delete: 
+      state: 
+        kind: Namespace
+        apiVersion: v1
+        metadata:
+          name: my-ns
+```
 
 ### Programmatic vs. Declarative
 It is important to understand that these declarative patterns are built upon programmatic ones. The low level constructs _(read native Kubernetes resources & custom resources)_ might be implemented in programming language(s) of one's choice. Use d-controller's YAMLs to aggregate these low level resources in a particular way to build a completely new kubernetes controller.
@@ -35,8 +80,14 @@ sudo make e2e-test
 
 ### Available Kubernetes controllers
 - [x] kind: Recipe
-- [ ] kind: HTTP
-- [ ] kind: HTTPPipe
-- [ ] kind: Command
+- [ ] kind: RecipeClass
+- [ ] kind: RecipeGroupReport
+- [ ] kind: RecipeDebug
+- [ ] kind: Blueprint
+- [-] kind: Validation
+- [ ] kind: CodeCov
+- [-] kind: HTTP
+- [ ] kind: HTTPFlow
+- [-] kind: Command
 - [ ] kind: DaemonJob
 - [ ] kind: UberLoop

--- a/common/schema/validation.go
+++ b/common/schema/validation.go
@@ -1,0 +1,300 @@
+/*
+Copyright 2020 The MayaData Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package schema
+
+import (
+	"encoding/json"
+	"fmt"
+	"regexp"
+	"strings"
+)
+
+const (
+	// InvalidPathMsg provides the invalid path information
+	InvalidPathMsg string = "Invalid path: %q"
+
+	// SupportedPathMsg provides all the supported paths
+	// information
+	SupportedPathMsg string = "Supported paths: %s"
+)
+
+// ErrorMessage is used to form the validation failure message
+type ErrorMessage struct {
+	Error  string `json:"error"`
+	Remedy string `json:"remedy,omitempty"`
+}
+
+// FieldPathValidation enables validating the fields in
+// yaml like structures
+type FieldPathValidation struct {
+	// Unstructured object whose fields will be validated
+	// against its supported schema
+	Target map[string]interface{}
+
+	// Nested field paths that are supported by this
+	// unstructured object's schema
+	SupportedPaths []string
+
+	// The path prefixes that can be ignored if it fails
+	// validation
+	//
+	// For example: 'metadata.labels' & 'metadata.annotations'
+	// can have any nested field name(s). In other words,
+	// metadata.labels.app is valid & so is metadata.labels.xyz
+	// since app as well as xyz are not managed by the schema.
+	UserAllowedPathPrefixes []string
+
+	// map of field to supported nested paths
+	fieldToSupportedPaths map[string][]string
+
+	// all the validation failures
+	failures []ErrorMessage
+
+	// additional info that can help in debugging
+	verbose []string
+}
+
+func (v *FieldPathValidation) Error() string {
+	if len(v.failures) == 0 {
+		return ""
+	}
+	var msg = struct {
+		Fails   []ErrorMessage `json:"failures"`
+		Verbose []string       `json:"verbose,omitempty"`
+	}{
+		Fails:   v.failures,
+		Verbose: v.verbose,
+	}
+	raw, err := json.MarshalIndent(
+		msg,
+		" ",
+		".",
+	)
+	if err != nil {
+		panic(err)
+	}
+	return string(raw)
+}
+
+// isSupportedPath returns true if the provided field path
+// is supported as part of the schema
+func (v *FieldPathValidation) isSupportedPath(fieldPath string) bool {
+	if fieldPath == "" {
+		return false
+	}
+
+	// Regex replace the digits with *
+	//
+	// NOTE:
+	//  One example is to replace field path patterns like
+	// - spec.employees.[1].name with spec.employees.[*].name
+	// - spec.employees.[10].name with spec.employees.[*].name
+	re := regexp.MustCompile(`\[([0-9]+)\]`)
+	regexFieldPath := re.ReplaceAllString(fieldPath, "[*]")
+
+	ok := func() bool {
+		for _, allowedPathPrefix := range v.UserAllowedPathPrefixes {
+			if strings.HasPrefix(regexFieldPath, allowedPathPrefix) {
+				// return true if fieldpath starts with user allowed
+				// field paths
+				return true
+			}
+		}
+		for _, supportedPath := range v.SupportedPaths {
+			if strings.HasPrefix(supportedPath, regexFieldPath) {
+				// return true if fieldpath is a prefix of any supported
+				// paths
+				return true
+			}
+		}
+		return false
+	}()
+	if !ok && fieldPath != regexFieldPath {
+		v.verbose = append(
+			v.verbose,
+			fmt.Sprintf(
+				"FieldPath %q was regex-ed as %q",
+				fieldPath,
+				regexFieldPath,
+			),
+		)
+	}
+
+	return ok
+}
+
+func (v *FieldPathValidation) getSupportedPathsForField(fieldName string) []string {
+	if fieldName == "" {
+		return nil
+	}
+	if v.fieldToSupportedPaths == nil {
+		// one time initialization
+		v.fieldToSupportedPaths = make(map[string][]string)
+		for _, supportedPath := range v.SupportedPaths {
+			if strings.Contains(supportedPath, fieldName) {
+				v.fieldToSupportedPaths[fieldName] = append(
+					v.fieldToSupportedPaths[fieldName],
+					supportedPath,
+				)
+			}
+		}
+	}
+	return v.fieldToSupportedPaths[fieldName]
+}
+
+func (v *FieldPathValidation) getRemedyMsgForField(fieldPath, fieldName string) string {
+	paths := v.getSupportedPathsForField(fieldName)
+	if len(paths) == 0 {
+		return fmt.Sprintf("Path %q is not part of schema", fieldPath)
+	}
+	return fmt.Sprintf(SupportedPathMsg, strings.Join(paths, ", "))
+}
+
+func (v *FieldPathValidation) validateFieldPaths(fieldPath string) {
+	// we are interested only for invalid paths
+	if !v.isSupportedPath(fieldPath) {
+		fields := strings.Split(fieldPath, ".")
+		// Remedey message is built from the last field name
+		lastField := fields[len(fields)-1]
+		// construct the validation failure message
+		v.failures = append(
+			v.failures,
+			ErrorMessage{
+				Error:  fmt.Sprintf(InvalidPathMsg, fieldPath),
+				Remedy: v.getRemedyMsgForField(fieldPath, lastField),
+			},
+		)
+	}
+}
+
+func (v *FieldPathValidation) isListAMap(list []interface{}) bool {
+	if len(list) == 0 {
+		// Can not determine the datatype of list item
+		// Hence, return false
+		return false
+	}
+	// Loop over the given list
+	for _, item := range list {
+		// verify if all items are of type map
+		_, ok := item.(map[string]interface{})
+		if !ok {
+			// No need to proceed since this is not a
+			// list of maps
+			return false
+		}
+	}
+	return true
+}
+
+// makeMapFromList converts the given list to its map equivalent
+//
+// NOTE:
+// 	The provided list of items is converted to a map where
+// each map pair is keyed by the list item's index
+//
+// For example, given the following list:
+//
+// - name: dope1
+//   age: 1
+// - name: dope2
+//   age: 2
+//
+// Above list gets converted into below map:
+//
+// [0]:
+//   name: dope1
+//   age: 1
+// [1]:
+//   name: dope2
+//   age: 2
+func (v *FieldPathValidation) makeMapFromList(list []interface{}) map[string]interface{} {
+	if len(list) == 0 {
+		return nil
+	}
+	result := make(map[string]interface{}, len(list))
+	for idx, item := range list {
+		result[fmt.Sprintf("[%d]", idx)] = item
+	}
+	return result
+}
+
+func (v *FieldPathValidation) validateFieldPathsOfMap(fieldPath string, given map[string]interface{}) {
+	var pathPrefix string
+	if fieldPath != "" {
+		pathPrefix = fmt.Sprintf("%s.", fieldPath)
+	}
+	for key, val := range given {
+		// Nested path is formed by placing a dot i.e. '.' with
+		// every field traversed
+		//
+		// NOTE:
+		//	Dot is placed only if provided fieldPath is not empty
+		newPath := fmt.Sprintf("%s%s", pathPrefix, key)
+		// This leads to recursive calls for nested field path
+		v.validate(newPath, val)
+	}
+}
+
+func (v *FieldPathValidation) validateFieldPathsOfListViaMap(fieldPath string, given []interface{}) {
+	// transform the list to map; list items are
+	// transformed into a map with its key(s) as the
+	// item's index
+	givenAsMap := v.makeMapFromList(given)
+	// once in map execute map based validation
+	v.validateFieldPathsOfMap(fieldPath, givenAsMap)
+}
+
+func (v *FieldPathValidation) validateFieldPathsOfArray(fieldPath string, given []interface{}) {
+	// If it looks like a list of map, validate list like a map
+	if v.isListAMap(given) {
+		v.validateFieldPathsOfListViaMap(fieldPath, given)
+		return
+	}
+	// List is a normal array of scalars
+	// Hence, validate the current fieldpath
+	v.validateFieldPaths(fieldPath)
+}
+
+// validate runs field path validations for specific data types
+//
+// NOTE:
+// It supports data types understood by k8s.io's unstructured
+// instance.
+func (v *FieldPathValidation) validate(fieldPath string, given interface{}) {
+	switch givenVal := given.(type) {
+	case map[string]interface{}:
+		v.validateFieldPathsOfMap(fieldPath, givenVal)
+	case []interface{}:
+		v.validateFieldPathsOfArray(fieldPath, givenVal)
+	default:
+		// given is either a scalar or null.
+		//
+		// NOTE:
+		// - We have traversed to the leaf of the object.
+		// - No further traversal needs to be done
+		v.validateFieldPaths(fieldPath)
+	}
+}
+
+// Validate validates the provided object against its supported paths
+func (v *FieldPathValidation) Validate() error {
+	v.validate("", v.Target)
+	if len(v.failures) == 0 {
+		return nil
+	}
+	return v
+}

--- a/common/schema/validation_test.go
+++ b/common/schema/validation_test.go
@@ -1,0 +1,1247 @@
+/*
+Copyright 2020 The MayaData Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package schema
+
+import (
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+	stringutil "mayadata.io/d-operators/common/string"
+)
+
+func TestValidationError(t *testing.T) {
+	var tests = map[string]struct {
+		Fails             []ErrorMessage
+		Verbose           []string
+		ExpectNonEmptyMsg bool
+	}{
+		"assert no panic with nil fails": {
+			Fails: nil,
+		},
+		"assert no panic with empty fails": {
+			Fails: []ErrorMessage{},
+		},
+		"assert no panic with one fail item": {
+			Fails: []ErrorMessage{
+				{
+					Error:  "err",
+					Remedy: "do something",
+				},
+			},
+			ExpectNonEmptyMsg: true,
+		},
+		"assert no panic with many fail items": {
+			Fails: []ErrorMessage{
+				{
+					Error:  "err",
+					Remedy: "do something",
+				},
+				{
+					Error:  "err again",
+					Remedy: "do something again",
+				},
+			},
+			ExpectNonEmptyMsg: true,
+		},
+		"assert no panic with many fail items & verbose messages": {
+			Fails: []ErrorMessage{
+				{
+					Error:  "got some err",
+					Remedy: "do something",
+				},
+				{
+					Error:  "got some err again",
+					Remedy: "do something again",
+				},
+			},
+			Verbose: []string{
+				"Path is not supported",
+			},
+			ExpectNonEmptyMsg: true,
+		},
+	}
+	for name, mock := range tests {
+		name := name
+		mock := mock
+		t.Run(name, func(t *testing.T) {
+			v := &FieldPathValidation{
+				failures: mock.Fails,
+				verbose:  mock.Verbose,
+			}
+			got := v.Error()
+			if mock.ExpectNonEmptyMsg && got == "" {
+				t.Fatalf("Expected error message got none")
+			}
+			if !mock.ExpectNonEmptyMsg && got != "" {
+				t.Fatalf("Expected no error message got: \n%s", got)
+			}
+		})
+	}
+}
+
+func TestValidationIsSupportedPath(t *testing.T) {
+	var tests = map[string]struct {
+		FieldPath      string
+		SupportedPaths []string
+		IsSupported    bool
+	}{
+		"No field path & No Supported path": {},
+		"No field path": {
+			SupportedPaths: []string{
+				"spec.metadata.labels",
+			},
+		},
+		"starts with metadata as field path": {
+			FieldPath: "metadata",
+			SupportedPaths: []string{
+				"metadata.labels",
+			},
+			IsSupported: true,
+		},
+		"with metadata as field path": {
+			FieldPath: "metadata",
+			SupportedPaths: []string{
+				"metadata",
+			},
+			IsSupported: true,
+		},
+		"with spec.employees1.name as field path": {
+			FieldPath: "spec.employees1.name",
+			SupportedPaths: []string{
+				"spec.employees1.name",
+			},
+			IsSupported: true,
+		},
+		"starts with spec.employees12.emp as field path": {
+			FieldPath: "spec.employees12.emp",
+			SupportedPaths: []string{
+				"spec.employees12.emp.name",
+			},
+			IsSupported: true,
+		},
+		"with spec.employees.[1] as field path - negative": {
+			FieldPath: "spec.employees.[1]",
+			SupportedPaths: []string{
+				"spec.employees",
+				"spec.employees.name",
+			},
+		},
+		"with spec.employees.[1] as field path": {
+			FieldPath: "spec.employees.[1]",
+			SupportedPaths: []string{
+				"spec.employees.[*]",
+				"spec.employees.[*].name",
+			},
+			IsSupported: true,
+		},
+		"with spec.employees.[1].name as field path - negative": {
+			FieldPath: "spec.employees.[1].name",
+			SupportedPaths: []string{
+				"spec.employees.[*]",
+				"spec.employees.[*].id",
+				"spec.employees.[*].age",
+			},
+		},
+		"with spec.employees.[11].name as field path": {
+			FieldPath: "spec.employees.[11].name",
+			SupportedPaths: []string{
+				"spec.employees.[*].name",
+			},
+			IsSupported: true,
+		},
+		"starts with spec.employees.[11].emp as field path": {
+			FieldPath: "spec.employees.[11].emp",
+			SupportedPaths: []string{
+				"spec.employees.[*].emp.age",
+			},
+			IsSupported: true,
+		},
+		"with spec.employees.[111].emp as field path": {
+			FieldPath: "spec.employees.[111].emp",
+			SupportedPaths: []string{
+				"spec.employees.[*].emp",
+			},
+			IsSupported: true,
+		},
+		"starts with spec.employees.[111].emp as field path": {
+			FieldPath: "spec.employees.[111].emp",
+			SupportedPaths: []string{
+				"spec.employees.[*].emp.name",
+			},
+			IsSupported: true,
+		},
+		"with spec.lob.[111].employees.[1] as field path": {
+			FieldPath: "spec.lob.[111].employees.[1]",
+			SupportedPaths: []string{
+				"spec.lob.[*].employees.[*]",
+			},
+			IsSupported: true,
+		},
+		"starts with spec.lob.[111].employees.[1] as field path": {
+			FieldPath: "spec.lob.[111].employees.[1]",
+			SupportedPaths: []string{
+				"spec.lob.[*].employees.[*].id",
+			},
+			IsSupported: true,
+		},
+	}
+	for name, mock := range tests {
+		name := name
+		mock := mock
+		t.Run(name, func(t *testing.T) {
+			v := &FieldPathValidation{
+				SupportedPaths: mock.SupportedPaths,
+			}
+			got := v.isSupportedPath(mock.FieldPath)
+			if mock.IsSupported != got {
+				t.Fatalf(
+					"Expected %t got %t",
+					mock.IsSupported,
+					got,
+				)
+			}
+		})
+	}
+}
+
+func TestValidationGetSupportedPathsForField(t *testing.T) {
+	var supportedPaths = []string{
+		"metadata.labels",
+		"metadata.annotations",
+		"spec.replicas",
+		"spec.containers",
+		"status.phase",
+		"status.replicas.running",
+	}
+	var tests = map[string]struct {
+		FieldName              string
+		ExpectedSupportedPaths []string
+	}{
+		"labels": {
+			FieldName: "labels",
+			ExpectedSupportedPaths: []string{
+				"metadata.labels",
+			},
+		},
+		"replicas": {
+			FieldName: "replicas",
+			ExpectedSupportedPaths: []string{
+				"spec.replicas",
+				"status.replicas.running",
+			},
+		},
+		"spec": {
+			FieldName: "spec",
+			ExpectedSupportedPaths: []string{
+				"spec.replicas",
+				"spec.containers",
+			},
+		},
+		"running": {
+			FieldName: "running",
+			ExpectedSupportedPaths: []string{
+				"status.replicas.running",
+			},
+		},
+		"does not exist": {
+			FieldName:              "does_not_exist",
+			ExpectedSupportedPaths: nil,
+		},
+		"empty name": {
+			FieldName:              "",
+			ExpectedSupportedPaths: nil,
+		},
+	}
+	for name, mock := range tests {
+		name := name
+		mock := mock
+		t.Run(name, func(t *testing.T) {
+			v := &FieldPathValidation{
+				SupportedPaths: supportedPaths,
+			}
+			got := v.getSupportedPathsForField(mock.FieldName)
+			eq := stringutil.NewEquality(got, mock.ExpectedSupportedPaths)
+			if eq.IsDiff() {
+				t.Fatalf(
+					"Expected no diff got \n%s",
+					cmp.Diff(got, mock.ExpectedSupportedPaths),
+				)
+			}
+		})
+	}
+}
+
+func TestValidationGetRemedyMsgForField(t *testing.T) {
+	var supportedPaths = []string{
+		"metadata.labels",
+		"metadata.annotations",
+		"spec.replicas",
+		"spec.containers",
+		"status.phase",
+		"status.replicas.running",
+	}
+	var tests = map[string]struct {
+		FieldName  string
+		IsEmptyMsg bool
+	}{
+		"labels": {
+			FieldName: "labels",
+		},
+		"replicas": {
+			FieldName: "replicas",
+		},
+		"spec": {
+			FieldName: "spec",
+		},
+		"running": {
+			FieldName: "running",
+		},
+		"does not exist": {
+			FieldName: "does_not_exist",
+		},
+		"empty name": {
+			FieldName: "",
+		},
+	}
+	for name, mock := range tests {
+		name := name
+		mock := mock
+		t.Run(name, func(t *testing.T) {
+			v := &FieldPathValidation{
+				SupportedPaths: supportedPaths,
+			}
+			got := v.getRemedyMsgForField("", mock.FieldName)
+			if mock.IsEmptyMsg && got != "" {
+				t.Fatalf("Expected no message got %s", got)
+			}
+			if !mock.IsEmptyMsg && got == "" {
+				t.Fatalf("Expected message got none")
+			}
+		})
+	}
+}
+
+func TestValidationValidateFieldPath(t *testing.T) {
+	var supportedPaths = []string{
+		"metadata.labels",
+		"metadata.annotations",
+		"spec.replicas",
+		"spec.containers",
+		"status.phase",
+		"status.replicas.running",
+	}
+	var tests = map[string]struct {
+		FieldPath      string
+		ExpectFailures bool
+	}{
+		"metadata": {
+			FieldPath: "metadata",
+		},
+		"labels": {
+			FieldPath:      "labels",
+			ExpectFailures: true,
+		},
+		"metadata.labels": {
+			FieldPath: "metadata.labels",
+		},
+		"replicas": {
+			FieldPath:      "replicas",
+			ExpectFailures: true,
+		},
+		"spec": {
+			FieldPath: "spec",
+		},
+		"spec.replicas": {
+			FieldPath: "spec.replicas",
+		},
+		"running": {
+			FieldPath:      "running",
+			ExpectFailures: true,
+		},
+		"status.replicas.running": {
+			FieldPath: "status.replicas.running",
+		},
+		"does not exist": {
+			FieldPath:      "does_not_exist",
+			ExpectFailures: true,
+		},
+		"empty name": {
+			FieldPath:      "",
+			ExpectFailures: true,
+		},
+	}
+	for name, mock := range tests {
+		name := name
+		mock := mock
+		t.Run(name, func(t *testing.T) {
+			v := &FieldPathValidation{
+				SupportedPaths: supportedPaths,
+			}
+			v.validateFieldPaths(mock.FieldPath)
+			if mock.ExpectFailures && len(v.failures) == 0 {
+				t.Fatalf("Expected failures got none")
+			}
+			if !mock.ExpectFailures && len(v.failures) != 0 {
+				t.Fatalf("Expected no failures got %v", v.failures)
+			}
+		})
+	}
+}
+
+func TestValidationIsListAMap(t *testing.T) {
+	var tests = map[string]struct {
+		List  []interface{}
+		IsMap bool
+	}{
+		"nil list": {
+			List: nil,
+		},
+		"empty list": {
+			List: []interface{}{},
+		},
+		"list of map": {
+			List: []interface{}{
+				map[string]interface{}{},
+			},
+			IsMap: true,
+		},
+		"list of nils": {
+			List: []interface{}{
+				nil,
+				nil,
+			},
+		},
+		"list of maps": {
+			List: []interface{}{
+				map[string]interface{}{
+					"key": "value",
+				},
+				map[string]interface{}{
+					"key1": "value1",
+				},
+			},
+			IsMap: true,
+		},
+		"list of scalars - string": {
+			List: []interface{}{
+				"hi",
+				"there",
+			},
+		},
+		"list of scalars - int": {
+			List: []interface{}{
+				10,
+				200,
+			},
+		},
+	}
+	for name, mock := range tests {
+		name := name
+		mock := mock
+		t.Run(name, func(t *testing.T) {
+			v := &FieldPathValidation{}
+			got := v.isListAMap(mock.List)
+			if got != mock.IsMap {
+				t.Fatalf(
+					"Expected ismap as %t got %t",
+					mock.IsMap,
+					got,
+				)
+			}
+		})
+	}
+}
+
+func TestValidationMakeMapFromList(t *testing.T) {
+	var tests = map[string]struct {
+		Given    []interface{}
+		Expected map[string]interface{}
+	}{
+		"nil list": {
+			Given:    nil,
+			Expected: nil,
+		},
+		"empty list": {
+			Given:    []interface{}{},
+			Expected: nil,
+		},
+		"list of nils": {
+			Given: []interface{}{
+				nil,
+				nil,
+			},
+			Expected: map[string]interface{}{
+				"[0]": nil,
+				"[1]": nil,
+			},
+		},
+		"list of string": {
+			Given: []interface{}{
+				"hi",
+				"there",
+			},
+			Expected: map[string]interface{}{
+				"[0]": "hi",
+				"[1]": "there",
+			},
+		},
+		"list of int": {
+			Given: []interface{}{
+				10,
+				11,
+			},
+			Expected: map[string]interface{}{
+				"[0]": 10,
+				"[1]": 11,
+			},
+		},
+		"list of map": {
+			Given: []interface{}{
+				map[string]interface{}{
+					"hi": 10,
+				},
+				map[string]interface{}{
+					"hello": 20,
+				},
+			},
+			Expected: map[string]interface{}{
+				"[0]": map[string]interface{}{
+					"hi": 10,
+				},
+				"[1]": map[string]interface{}{
+					"hello": 20,
+				},
+			},
+		},
+	}
+	for name, mock := range tests {
+		name := name
+		mock := mock
+		t.Run(name, func(t *testing.T) {
+			v := &FieldPathValidation{}
+			got := v.makeMapFromList(mock.Given)
+			diff := cmp.Diff(mock.Expected, got)
+			if diff != "" {
+				t.Fatalf("Expected no diff got: \n%s", diff)
+			}
+		})
+	}
+}
+
+func TestValidationValidateFieldPathsOfMap(t *testing.T) {
+	var supportedPaths = []string{
+		"spec.replicas",
+		"spec.containers",
+		"status.phase",
+		"status.replicas.running",
+	}
+	var tests = map[string]struct {
+		BasePath string
+		Given    map[string]interface{}
+		IsValid  bool
+	}{
+		// ---------------------------------------
+		// spec.replicas
+		// ---------------------------------------
+		"missing base path for replicas": {
+			BasePath: "",
+			Given: map[string]interface{}{
+				"replicas": 1,
+			},
+		},
+		"invalid base path for replicas": {
+			BasePath: "metadata",
+			Given: map[string]interface{}{
+				"replicas": 2,
+			},
+		},
+		"valid base path for 0 spec replicas": {
+			BasePath: "spec",
+			Given: map[string]interface{}{
+				"replicas": 0,
+			},
+			IsValid: true,
+		},
+		"valid path spec.replicas": {
+			BasePath: "spec",
+			Given: map[string]interface{}{
+				"replicas": 1,
+			},
+			IsValid: true,
+		},
+		// ---------------------------------------
+		// status.replicas.running
+		// ---------------------------------------
+		"invalid base path for status.replicas.running": {
+			BasePath: "status.replicas",
+			Given: map[string]interface{}{
+				"replicas": map[string]interface{}{
+					"running": 1,
+				},
+			},
+		},
+		"valid path status.replicas.running": {
+			BasePath: "status",
+			Given: map[string]interface{}{
+				"replicas": map[string]interface{}{
+					"running": 1,
+				},
+			},
+			IsValid: true,
+		},
+		// ---------------------------------------
+		// metadata.labels
+		// ---------------------------------------
+		"missing base path for labels": {
+			BasePath: "",
+			Given: map[string]interface{}{
+				"labels": map[string]interface{}{
+					"app": "dope",
+				},
+			},
+		},
+		"invalid base path for labels": {
+			BasePath: "meta",
+			Given: map[string]interface{}{
+				"labels": map[string]interface{}{
+					"app": "dope",
+				},
+			},
+		},
+		"valid base path for nil labels": {
+			BasePath: "metadata",
+			Given: map[string]interface{}{
+				"labels": nil,
+			},
+			IsValid: true,
+		},
+		"valid base path for labels": {
+			BasePath: "metadata",
+			Given: map[string]interface{}{
+				"labels": map[string]interface{}{
+					"app": "dope",
+				},
+			},
+			IsValid: true,
+		},
+		// ---------------------------------------
+		// metadata.annotations
+		// ---------------------------------------
+		"valid base path for nil annotations": {
+			BasePath: "metadata",
+			Given: map[string]interface{}{
+				"annotations": nil,
+			},
+			IsValid: true,
+		},
+		"valid base path for annotations": {
+			BasePath: "metadata",
+			Given: map[string]interface{}{
+				"annotations": map[string]interface{}{
+					"app": "dope",
+				},
+			},
+			IsValid: true,
+		},
+	}
+	for name, mock := range tests {
+		name := name
+		mock := mock
+		t.Run(name, func(t *testing.T) {
+			v := &FieldPathValidation{
+				SupportedPaths: supportedPaths,
+				UserAllowedPathPrefixes: []string{
+					"metadata.labels",
+					"metadata.annotations",
+				},
+			}
+			v.validateFieldPathsOfMap(mock.BasePath, mock.Given)
+			if mock.IsValid && len(v.failures) != 0 {
+				t.Fatalf("Expected valid map got: \n%s", v.Error())
+			}
+			if !mock.IsValid && len(v.failures) == 0 {
+				t.Fatalf("Expected invalid map got none")
+			}
+		})
+	}
+}
+
+func TestValidationValidateFieldPathsOfListViaMap(t *testing.T) {
+	var supportedPaths = []string{
+		"spec.replicas",
+		"spec.containers",
+		"status.phase",
+		"status.replicas.[*].running",
+	}
+	var tests = map[string]struct {
+		BasePath string
+		Given    []interface{}
+		IsValid  bool
+	}{
+		// ---------------------------------------
+		// spec.replicas
+		// ---------------------------------------
+		"invalid list based path spec.replicas": {
+			BasePath: "spec",
+			Given: []interface{}{
+				map[string]interface{}{
+					"replicas": 1,
+				},
+			},
+		},
+		// ---------------------------------------
+		// status.replicas.running
+		// ---------------------------------------
+		"invalid list based path status.replicas.running": {
+			BasePath: "status",
+			Given: []interface{}{
+				map[string]interface{}{
+					"replicas": map[string]interface{}{
+						"running": 1,
+					},
+				},
+			},
+		},
+		"valid list based path status.replicas.[*].running": {
+			BasePath: "status.replicas",
+			Given: []interface{}{
+				map[string]interface{}{
+					"running": true,
+				},
+				map[string]interface{}{
+					"running": false,
+				},
+			},
+			IsValid: true,
+		},
+		// ---------------------------------------
+		// metadata.labels
+		// ---------------------------------------
+		"labels cannot be used as list": {
+			BasePath: "metadata",
+			Given: []interface{}{
+				map[string]interface{}{
+					"labels": map[string]interface{}{
+						"app": "dope",
+					},
+				},
+			},
+		},
+		// ---------------------------------------
+		// metadata.annotations
+		// ---------------------------------------
+		"annotations can not be used as list": {
+			BasePath: "metadata",
+			Given: []interface{}{
+				map[string]interface{}{
+					"annotations": map[string]interface{}{
+						"app": "dope",
+					},
+				},
+			},
+		},
+	}
+	for name, mock := range tests {
+		name := name
+		mock := mock
+		t.Run(name, func(t *testing.T) {
+			v := &FieldPathValidation{
+				SupportedPaths: supportedPaths,
+				UserAllowedPathPrefixes: []string{
+					"metadata.labels",
+					"metadata.annotations",
+				},
+			}
+			v.validateFieldPathsOfListViaMap(mock.BasePath, mock.Given)
+			if mock.IsValid && len(v.failures) != 0 {
+				t.Fatalf("Expected valid list got: \n%s", v.Error())
+			}
+			if !mock.IsValid && len(v.failures) == 0 {
+				t.Fatalf("Expected invalid list got none")
+			}
+		})
+	}
+}
+
+func TestValidationValidateFieldPathsOfArray(t *testing.T) {
+	var supportedPaths = []string{
+		"spec.tags", // scalar list
+		"spec.replicas",
+		"spec.containers.[*].name",  // list of maps
+		"spec.containers.[*].image", // list of maps
+		"status.phase",
+		"status.replicas.[*].running", // list of maps
+	}
+	var tests = map[string]struct {
+		BasePath string
+		Given    []interface{}
+		IsValid  bool
+	}{
+		// ---------------------------------------
+		// spec.tags
+		// ---------------------------------------
+		"valid scalar list spec.tags": {
+			BasePath: "spec.tags",
+			Given: []interface{}{
+				"hi",
+				"there",
+				"how-do-you-do",
+			},
+			IsValid: true,
+		},
+		// ---------------------------------------
+		// spec.replicas
+		// ---------------------------------------
+		"invalid list based path spec.replicas": {
+			BasePath: "spec",
+			Given: []interface{}{
+				map[string]interface{}{
+					"replicas": 1,
+				},
+			},
+		},
+		// ---------------------------------------
+		// status.replicas.[*].running
+		// ---------------------------------------
+		"invalid list based path status.replicas.running": {
+			BasePath: "status",
+			Given: []interface{}{
+				map[string]interface{}{
+					"replicas": map[string]interface{}{
+						"running": 1,
+					},
+				},
+			},
+		},
+		"valid list based path status.replicas.[*].running": {
+			BasePath: "status.replicas",
+			Given: []interface{}{
+				map[string]interface{}{
+					"running": true,
+				},
+				map[string]interface{}{
+					"running": false,
+				},
+			},
+			IsValid: true,
+		},
+		// -------------------------------------
+		// spec.containers.[*].image
+		// spec.containers.[*].name
+		// -------------------------------------
+		"invalid list based path spec.containers.[*].desc": {
+			BasePath: "spec.containers",
+			Given: []interface{}{
+				map[string]interface{}{
+					"name":  "my-nginx-con",
+					"image": "nginx",
+					"desc":  "nginx",
+				},
+				map[string]interface{}{
+					"image": "dope",
+				},
+			},
+		},
+		"valid list based path spec.containers.[*].image": {
+			BasePath: "spec.containers",
+			Given: []interface{}{
+				map[string]interface{}{
+					"name":  "my-nginx-con",
+					"image": "nginx",
+				},
+				map[string]interface{}{
+					"image": "dope",
+				},
+			},
+			IsValid: true,
+		},
+		// ---------------------------------------
+		// metadata.labels
+		// ---------------------------------------
+		"labels cannot be used as list": {
+			BasePath: "metadata",
+			Given: []interface{}{
+				map[string]interface{}{
+					"labels": map[string]interface{}{
+						"app": "dope",
+					},
+				},
+			},
+		},
+		// ---------------------------------------
+		// metadata.annotations
+		// ---------------------------------------
+		"annotations can not be used as list": {
+			BasePath: "metadata",
+			Given: []interface{}{
+				map[string]interface{}{
+					"annotations": map[string]interface{}{
+						"app": "dope",
+					},
+				},
+			},
+		},
+	}
+	for name, mock := range tests {
+		name := name
+		mock := mock
+		t.Run(name, func(t *testing.T) {
+			v := &FieldPathValidation{
+				SupportedPaths: supportedPaths,
+				UserAllowedPathPrefixes: []string{
+					"metadata.labels",
+					"metadata.annotations",
+				},
+			}
+			v.validateFieldPathsOfArray(mock.BasePath, mock.Given)
+			if mock.IsValid && len(v.failures) != 0 {
+				t.Fatalf("Expected valid array got: \n%s", v.Error())
+			}
+			if !mock.IsValid && len(v.failures) == 0 {
+				t.Fatalf("Expected invalid array got none")
+			}
+		})
+	}
+}
+
+func TestValidationValidatePrivate(t *testing.T) {
+	var supportedPaths = []string{
+		"spec.tags", // scalar list
+		"spec.replicas",
+		"spec.containers.[*].name",  // list of maps
+		"spec.containers.[*].image", // list of maps
+		"status.phase",
+		"status.replicas.[*].running", // list of maps
+	}
+	var tests = map[string]struct {
+		BasePath string
+		Given    interface{}
+		IsValid  bool
+	}{
+		// ---------------------------------------
+		// spec.tags
+		// ---------------------------------------
+		"valid scalar list spec.tags": {
+			BasePath: "spec.tags",
+			Given: []interface{}{
+				"hi",
+				"there",
+				"how-do-you-do",
+			},
+			IsValid: true,
+		},
+		// ---------------------------------------
+		// spec.replicas
+		// ---------------------------------------
+		"invalid list based path spec.replicas": {
+			BasePath: "spec",
+			Given: []interface{}{
+				map[string]interface{}{
+					"replicas": 1,
+				},
+			},
+		},
+		"valid spec.replicas": {
+			BasePath: "spec",
+			Given: map[string]interface{}{
+				"replicas": 1,
+			},
+			IsValid: true,
+		},
+		// ---------------------------------------
+		// status.replicas.[*].running
+		// ---------------------------------------
+		"invalid list based path status.replicas.running": {
+			BasePath: "status",
+			Given: []interface{}{
+				map[string]interface{}{
+					"replicas": map[string]interface{}{
+						"running": 1,
+					},
+				},
+			},
+		},
+		"valid list based path status.replicas.[*].running": {
+			BasePath: "status.replicas",
+			Given: []interface{}{
+				map[string]interface{}{
+					"running": true,
+				},
+				map[string]interface{}{
+					"running": false,
+				},
+			},
+			IsValid: true,
+		},
+		// -------------------------------------
+		// spec.containers.[*].image
+		// spec.containers.[*].name
+		// -------------------------------------
+		"invalid list based path spec.containers.[*].desc": {
+			BasePath: "spec.containers",
+			Given: []interface{}{
+				map[string]interface{}{
+					"name":  "my-nginx-con",
+					"image": "nginx",
+					"desc":  "nginx",
+				},
+				map[string]interface{}{
+					"image": "dope",
+				},
+			},
+		},
+		"valid list based path spec.containers.[*].image": {
+			BasePath: "spec.containers",
+			Given: []interface{}{
+				map[string]interface{}{
+					"name":  "my-nginx-con",
+					"image": "nginx",
+				},
+				map[string]interface{}{
+					"image": "dope",
+				},
+			},
+			IsValid: true,
+		},
+		// ---------------------------------------
+		// metadata.labels
+		// ---------------------------------------
+		"valid metadata.labels": {
+			BasePath: "metadata",
+			Given: map[string]interface{}{
+				"labels": map[string]interface{}{
+					"app": "dope",
+				},
+			},
+			IsValid: true,
+		},
+		"invalid labels": {
+			BasePath: "",
+			Given: map[string]interface{}{
+				"labels": map[string]interface{}{
+					"app": "dope",
+				},
+			},
+		},
+		// ---------------------------------------
+		// metadata.annotations
+		// ---------------------------------------
+		"valid metadata.annotations": {
+			BasePath: "metadata",
+			Given: map[string]interface{}{
+				"annotations": map[string]interface{}{
+					"app": "dope",
+				},
+			},
+			IsValid: true,
+		},
+		"invalid annotations": {
+			BasePath: "",
+			Given: map[string]interface{}{
+				"annotations": map[string]interface{}{
+					"app": "dope",
+				},
+			},
+		},
+	}
+	for name, mock := range tests {
+		name := name
+		mock := mock
+		t.Run(name, func(t *testing.T) {
+			v := &FieldPathValidation{
+				SupportedPaths: supportedPaths,
+				UserAllowedPathPrefixes: []string{
+					"metadata.labels",
+					"metadata.annotations",
+				},
+			}
+			v.validate(mock.BasePath, mock.Given)
+			if mock.IsValid && len(v.failures) != 0 {
+				t.Fatalf("Expected valid schema got: \n%s", v.Error())
+			}
+			if !mock.IsValid && len(v.failures) == 0 {
+				t.Fatalf("Expected invalid schema got none")
+			}
+		})
+	}
+}
+
+func TestValidationValidate(t *testing.T) {
+	var supportedPaths = []string{
+		"spec.tags", // scalar list
+		"spec.replicas",
+		"spec.containers.[*].name",  // list of maps
+		"spec.containers.[*].image", // list of maps
+		"status.phase",
+		"status.replicas.[*].running", // list of maps
+	}
+	var tests = map[string]struct {
+		Given   map[string]interface{}
+		IsValid bool
+	}{
+		// ---------------------------------------
+		// spec.tags
+		// ---------------------------------------
+		"valid scalar list spec.tags": {
+			Given: map[string]interface{}{
+				"spec": map[string]interface{}{
+					"tags": []interface{}{
+						"hi",
+						"there",
+						"how-do-you-do",
+					},
+				},
+			},
+			IsValid: true,
+		},
+		// ---------------------------------------
+		// spec.replicas
+		// ---------------------------------------
+		"valid spec.replicas": {
+			Given: map[string]interface{}{
+				"spec": map[string]interface{}{
+					"replicas": 1,
+				},
+			},
+			IsValid: true,
+		},
+		// ---------------------------------------
+		// status.replicas.[*].running
+		// ---------------------------------------
+		"invalid list based path status.replicas.running": {
+			Given: map[string]interface{}{
+				"status": map[string]interface{}{
+					"replicas": map[string]interface{}{
+						"running": 1,
+					},
+				},
+			},
+		},
+		"valid list based path status.replicas.[*].running": {
+			Given: map[string]interface{}{
+				"status": map[string]interface{}{
+					"replicas": []interface{}{
+						map[string]interface{}{
+							"running": true,
+						},
+						map[string]interface{}{
+							"running": false,
+						},
+					},
+				},
+			},
+			IsValid: true,
+		},
+		// -------------------------------------
+		// spec.containers.[*].image
+		// spec.containers.[*].name
+		// -------------------------------------
+		"invalid list based path spec.containers.[*].desc": {
+			Given: map[string]interface{}{
+				"spec": map[string]interface{}{
+					"containers": []interface{}{
+						map[string]interface{}{
+							"name":  "my-nginx-con",
+							"image": "nginx",
+							"desc":  "nginx",
+						},
+						map[string]interface{}{
+							"image": "dope",
+						},
+					},
+				},
+			},
+		},
+		"valid list based path spec.containers.[*].image": {
+			Given: map[string]interface{}{
+				"spec": map[string]interface{}{
+					"containers": []interface{}{
+						map[string]interface{}{
+							"name":  "my-nginx-con",
+							"image": "nginx",
+						},
+						map[string]interface{}{
+							"image": "dope",
+						},
+					},
+				},
+			},
+			IsValid: true,
+		},
+		// ---------------------------------------
+		// metadata.labels
+		// ---------------------------------------
+		"valid metadata.labels": {
+			Given: map[string]interface{}{
+				"metadata": map[string]interface{}{
+					"labels": map[string]interface{}{
+						"app": "dope",
+					},
+				},
+			},
+			IsValid: true,
+		},
+		"invalid labels": {
+			Given: map[string]interface{}{
+				"labels": map[string]interface{}{
+					"app": "dope",
+				},
+			},
+		},
+		// ---------------------------------------
+		// metadata.annotations
+		// ---------------------------------------
+		"valid metadata.annotations": {
+			Given: map[string]interface{}{
+				"metadata": map[string]interface{}{
+					"annotations": map[string]interface{}{
+						"app": "dope",
+					},
+				},
+			},
+			IsValid: true,
+		},
+		"invalid annotations": {
+			Given: map[string]interface{}{
+				"annotations": map[string]interface{}{
+					"app": "dope",
+				},
+			},
+		},
+	}
+	for name, mock := range tests {
+		name := name
+		mock := mock
+		t.Run(name, func(t *testing.T) {
+			v := &FieldPathValidation{
+				Target:         mock.Given,
+				SupportedPaths: supportedPaths,
+				UserAllowedPathPrefixes: []string{
+					"metadata.labels",
+					"metadata.annotations",
+				},
+			}
+			got := v.Validate()
+			if mock.IsValid && got != nil {
+				t.Fatalf("Expected valid schema got: \n%s", got.Error())
+			}
+			if !mock.IsValid && got == nil {
+				t.Fatalf("Expected invalid schema got none")
+			}
+		})
+	}
+}

--- a/go.sum
+++ b/go.sum
@@ -36,6 +36,7 @@ github.com/blang/semver v3.5.0+incompatible h1:CGxCgetQ64DKk7rdZ++Vfnb1+ogGNnB17
 github.com/blang/semver v3.5.0+incompatible/go.mod h1:kRBLl5iJ+tD4TcOOxsy/0fnwebNt5EWlYSAyrTnjyyk=
 github.com/client9/misspell v0.3.4/go.mod h1:qj6jICC3Q7zFZvVWo7KLAzC3yx5G7kyvSDkc90ppPyw=
 github.com/cockroachdb/datadriven v0.0.0-20190809214429-80d97fb3cbaa/go.mod h1:zn76sxSg3SzpJ0PPJaLDCu+Bu0Lg3sKTORVIj19EIF8=
+github.com/coreos/etcd v3.3.10+incompatible h1:jFneRYjIvLMLhDLCzuTuU4rSJUjRplcJQ7pD7MnhC04=
 github.com/coreos/etcd v3.3.10+incompatible/go.mod h1:uF7uidLiAD3TWHmW31ZFd/JWoc32PjwdhPthX9715RE=
 github.com/coreos/go-etcd v2.0.0+incompatible/go.mod h1:Jez6KQU2B/sWsbdaef3ED8NzMklzPG4d5KIOhIy30Tk=
 github.com/coreos/go-oidc v2.1.0+incompatible/go.mod h1:CgnwVTmzoESiwO9qyAFEMiHoZ1nMCKZlZ9V6mm3/LKc=


### PR DESCRIPTION
This commit introduces validation logic to validate any yaml
structures' field paths. For example 'metadata.labels' is valid
while 'labels' is not valid.

Future commits will make use of this feature in respective custom
resources during their reconciliations.

Signed-off-by: AmitKumarDas <amit.das@mayadata.io>