### PR TITLE
feat(recipe): add support for string based value(s) in pathcheck

### DIFF
--- a/pkg/recipe/path_check_test.go
+++ b/pkg/recipe/path_check_test.go
@@ -1,0 +1,128 @@
+package recipe
+
+import (
+	"testing"
+
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	types "mayadata.io/d-operators/types/recipe"
+)
+
+func TestPathCheckingAssertValueString(t *testing.T) {
+	var tests = map[string]struct {
+		State                 *unstructured.Unstructured
+		TaskName              string
+		PathCheck             string
+		Path                  string
+		Value                 string
+		retryIfValueEquals    bool
+		retryIfValueNotEquals bool
+		IsError               bool
+		ExpectedAssert        bool
+	}{
+		"assert ipaddress None == None": {
+			State: &unstructured.Unstructured{
+				Object: map[string]interface{}{
+					"apiVersion": "v1",
+					"kind":       "Service",
+					"metadata": map[string]interface{}{
+						"name":      "test",
+						"namespace": "default",
+					},
+					"spec": map[string]interface{}{
+						"ipAddress": "None",
+					},
+				},
+			},
+			Path:                  "spec.ipAddress",
+			Value:                 "None",
+			retryIfValueNotEquals: true,
+			ExpectedAssert:        true,
+		},
+		"assert ipaddress ip != 12.123.12.11": {
+			State: &unstructured.Unstructured{
+				Object: map[string]interface{}{
+					"apiVersion": "v1",
+					"kind":       "Service",
+					"metadata": map[string]interface{}{
+						"name":      "test",
+						"namespace": "default",
+					},
+					"spec": map[string]interface{}{
+						"ipAddress": "12.123.12.11",
+					},
+				},
+			},
+			Path:               "spec.ipAddress",
+			Value:              "None",
+			retryIfValueEquals: true,
+			ExpectedAssert:     true,
+		},
+		"assert ipaddress ip != ": {
+			State: &unstructured.Unstructured{
+				Object: map[string]interface{}{
+					"apiVersion": "v1",
+					"kind":       "Service",
+					"metadata": map[string]interface{}{
+						"name":      "test",
+						"namespace": "default",
+					},
+					"spec": map[string]interface{}{
+						"ipAddress": "12.123.12.11",
+					},
+				},
+			},
+			Path:               "spec.ipAddress",
+			Value:              "",
+			retryIfValueEquals: true,
+			ExpectedAssert:     true,
+		},
+		"assert ipaddress Nil != None": {
+			State: &unstructured.Unstructured{
+				Object: map[string]interface{}{
+					"apiVersion": "v1",
+					"kind":       "Service",
+					"metadata": map[string]interface{}{
+						"name":      "test",
+						"namespace": "default",
+					},
+					"spec": map[string]interface{}{
+						"ipAddress": "None",
+					},
+				},
+			},
+			Path:                  "spec.ipAddress",
+			Value:                 "Nil",
+			retryIfValueNotEquals: true,
+			ExpectedAssert:        false,
+		},
+	}
+	for scenario, tObj := range tests {
+		scenario := scenario
+		tObj := tObj
+		t.Run(scenario, func(t *testing.T) {
+			pc := &PathChecking{
+				PathCheck: types.PathCheck{
+					Path:  tObj.Path,
+					Value: tObj.Value,
+				},
+				retryIfValueEquals:    tObj.retryIfValueEquals,
+				retryIfValueNotEquals: tObj.retryIfValueNotEquals,
+				result:                &types.PathCheckResult{},
+			}
+			got, err := pc.assertValueString(tObj.State)
+			if tObj.IsError && err == nil {
+				t.Fatalf("Expected error got none")
+			}
+			if !tObj.IsError && err != nil {
+				t.Fatalf("Expected no error got %s", err.Error())
+			}
+			if tObj.IsError {
+				return
+			}
+			if got != tObj.ExpectedAssert {
+				t.Fatalf("Expected assert = %t got %t", tObj.ExpectedAssert, got)
+			}
+
+		})
+	}
+}

--- a/types/recipe/patch_check.go
+++ b/types/recipe/patch_check.go
@@ -84,6 +84,10 @@ const (
 	// PathValueDataTypeFloat64 expects path's value with float64
 	// as its data type
 	PathValueDataTypeFloat64 PathValueDataType = "float64"
+
+	// PathValueDataTypeString expects path's value with string
+	// as its data type
+	PathValueDataTypeString PathValueDataType = "string"
 )
 
 // PathCheck verifies expected field value against


### PR DESCRIPTION
This PR adds support to verify string based value in `pathCheck` field

#### Sample experiment 
- Following recipe asserts `spec.clusterIP` is set to `None`
```yaml
apiVersion: dope.mayadata.io/v1
kind: Recipe
metadata:
  name: svc-1
  namespace: d-testing
spec:
  tasks:
  - name: assert-svc-running
    assert:
      state:
        kind: Service
        apiVersion: v1
        metadata:
          name: cassandra
          namespace: kubera
      pathCheck:
        path: spec.clusterIP
        pathCheckOperator: Equals
        value: None # this is a string value
```

#### Output:

$ kubectl describe `recipe.dope.mayadata.io/svc-1` -n `d-testing`
```
Name:         svc-1
Namespace:    d-testing
Status:
  Execution Time:
    Readable Value:    4ms
    Value In Seconds:  0.004093446
  Phase:               Completed
  Task Count:
    Failed:   0
    Skipped:  0
    Total:    1
    Warning:  0
  Tasks:
    Assert - Svc - Running:
      Message:  PathCheckValueEquals: Resource kubera cassandra: GVK /v1, Kind=Service: TaskName assert-svc-running
      Phase:    Passed
      Step:     1
      Verbose:  Expected value None got None
```

Signed-off-by: Amit Bhatt <amitbhatt818@gmail.com>