### PR TITLE
feat(list): add list option in recipe package

### DIFF
--- a/pkg/recipe/list.go
+++ b/pkg/recipe/list.go
@@ -1,0 +1,111 @@
+/*
+Copyright 2020 The MayaData Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    https://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package recipe
+
+import (
+	"fmt"
+
+	"k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1beta1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	types "mayadata.io/d-operators/types/recipe"
+)
+
+// Listable helps listing desired state from the cluster
+type Listable struct {
+	BaseRunner
+	List *types.List
+
+	result *types.ListResult
+	err    error
+}
+
+// ListableConfig helps in creating new instance of Listable
+type ListableConfig struct {
+	BaseRunner
+	List *types.List
+}
+
+// NewLister returns a new instance of Listable
+func NewLister(config ListableConfig) *Listable {
+	return &Listable{
+		BaseRunner: config.BaseRunner,
+		List:       config.List,
+		result:     &types.ListResult{},
+	}
+}
+
+func (l *Listable) listCRDs() (*types.ListResult, error) {
+	var crd *v1beta1.CustomResourceDefinition
+	err := UnstructToTyped(l.List.State, &crd)
+	if err != nil {
+		return nil, err
+	}
+	// use crd client to list crds
+	items, err := l.crdClient.
+		CustomResourceDefinitions().
+		List(metav1.ListOptions{})
+	if err != nil {
+		return nil, err
+	}
+	return &types.ListResult{
+		Phase: types.ListStatusPassed,
+		Message: fmt.Sprintf(
+			"List CRD: Kind %s: APIVersion %s",
+			crd.Spec.Names.Singular,
+			crd.Spec.Group+"/"+crd.Spec.Version,
+		),
+		V1Beta1CRDItems: items,
+	}, nil
+}
+
+func (l *Listable) listResources() (*types.ListResult, error) {
+	var message = fmt.Sprintf(
+		"List resources with %s / %s: GVK %s",
+		l.List.State.GetNamespace(),
+		l.List.State.GetName(),
+		l.List.State.GroupVersionKind(),
+	)
+	client, err := l.GetClientForAPIVersionAndKind(
+		l.List.State.GetAPIVersion(),
+		l.List.State.GetKind(),
+	)
+	if err != nil {
+		return nil, err
+	}
+	items, err := client.
+		Namespace(l.List.State.GetNamespace()).
+		List(metav1.ListOptions{}) // TODO add label selector
+	if err != nil {
+		return nil, err
+	}
+	return &types.ListResult{
+		Phase:   types.ListStatusPassed,
+		Message: message,
+		Items:   items,
+	}, nil
+}
+
+// Run executes applying the desired state against the
+// cluster
+func (l *Listable) Run() (*types.ListResult, error) {
+	if l.List.State.GetKind() == "CustomResourceDefinition" {
+		// list CRDs
+		return l.listCRDs()
+	}
+	return l.listResources()
+}

--- a/types/recipe/list.go
+++ b/types/recipe/list.go
@@ -1,0 +1,84 @@
+/*
+Copyright 2020 The MayaData Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    https://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package types
+
+import (
+	"encoding/json"
+
+	"k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1beta1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+)
+
+// List represents the desired state that needs to
+// be listed from the cluster
+type List struct {
+	// Desired state that needs to be listed from the
+	// Kubernetes cluster
+	State *unstructured.Unstructured `json:"state"`
+}
+
+// String implements the Stringer interface
+func (l List) String() string {
+	raw, err := json.MarshalIndent(
+		l,
+		" ",
+		".",
+	)
+	if err != nil {
+		panic(err)
+	}
+	return string(raw)
+}
+
+// ListStatusPhase is a typed definition to determine the
+// result of executing a list invocation
+type ListStatusPhase string
+
+const (
+	// ListStatusPassed defines a successful list
+	ListStatusPassed ListStatusPhase = "Passed"
+
+	// ListStatusWarning defines a list that resulted in warnings
+	ListStatusWarning ListStatusPhase = "Warning"
+
+	// ListStatusFailed defines a failed list
+	ListStatusFailed ListStatusPhase = "Failed"
+)
+
+// ToTaskStatusPhase transforms ListStatusPhase to TaskStatusPhase
+func (phase ListStatusPhase) ToTaskStatusPhase() TaskStatusPhase {
+	switch phase {
+	case ListStatusPassed:
+		return TaskStatusPassed
+	case ListStatusFailed:
+		return TaskStatusFailed
+	case ListStatusWarning:
+		return TaskStatusWarning
+	default:
+		return ""
+	}
+}
+
+// ListResult holds the result of the list operation
+type ListResult struct {
+	Phase           ListStatusPhase                       `json:"phase"`
+	Message         string                                `json:"message,omitempty"`
+	Verbose         string                                `json:"verbose,omitempty"`
+	Warning         string                                `json:"warning,omitempty"`
+	V1Beta1CRDItems *v1beta1.CustomResourceDefinitionList `json:"v1b1CRDs,omitempty"`
+	Items           *unstructured.UnstructuredList        `json:"items,omitempty"`
+}


### PR DESCRIPTION
This commit allows one to list any type of Kubernetes resources
including CRDs. This option is currently exposed to be consumed by
packages other than recipe within d-operator as well as by
libraries consuming d-operators.

Signed-off-by: AmitKumarDas <amit.das@mayadata.io>