### PR TITLE
feat(crd): create & apply CRD can ignore discovery if set

### DIFF
--- a/pkg/recipe/apply.go
+++ b/pkg/recipe/apply.go
@@ -225,11 +225,13 @@ func (a *Applyable) createCRD() (*types.ApplyResult, error) {
 				nil,
 			)
 	})
-	// run an additional step to wait till this CRD
-	// is discovered at apiserver
-	err = a.postCreateCRD(crd)
-	if err != nil {
-		return nil, err
+	if !a.Apply.IgnoreDiscovery {
+		// run an additional step to wait till this CRD
+		// is discovered at apiserver
+		err = a.postCreateCRD(crd)
+		if err != nil {
+			return nil, err
+		}
 	}
 	return &types.ApplyResult{
 		Phase: types.ApplyStatusPassed,

--- a/pkg/recipe/create.go
+++ b/pkg/recipe/create.go
@@ -248,11 +248,13 @@ func (c *Creatable) createCRD() (*types.CreateResult, error) {
 				nil,
 			)
 	})
-	// run an additional step to wait till this CRD
-	// is discovered at apiserver
-	err = c.postCreateCRD(crd)
-	if err != nil {
-		return nil, err
+	if !c.Create.IgnoreDiscovery {
+		// run an additional step to wait till this CRD
+		// is discovered at apiserver
+		err = c.postCreateCRD(crd)
+		if err != nil {
+			return nil, err
+		}
 	}
 	return &types.CreateResult{
 		Phase: types.CreateStatusPassed,

--- a/types/recipe/apply.go
+++ b/types/recipe/apply.go
@@ -47,6 +47,13 @@ type Apply struct {
 	// NOTE:
 	//	Presence of Targets implies an update operation
 	Targets metac.ResourceSelector `json:"targets,omitempty"`
+
+	// IgnoreDiscovery if set to true will not retry till
+	// resource gets discovered
+	//
+	// NOTE:
+	//	This is only applicable for kind: CustomResourceDefinition
+	IgnoreDiscovery bool
 }
 
 // String implements the Stringer interface

--- a/types/recipe/create.go
+++ b/types/recipe/create.go
@@ -29,6 +29,13 @@ type Create struct {
 
 	// Desired count that needs to be created
 	Replicas *int `json:"replicas,omitempty"`
+
+	// IgnoreDiscovery if set to true will not retry till
+	// resource gets discovered
+	//
+	// NOTE:
+	//	This is only applicable for kind: CustomResourceDefinition
+	IgnoreDiscovery bool
 }
 
 // String implements the Stringer interface


### PR DESCRIPTION
Recipe based create or apply action introduces IgnoreDiscovery
boolean flag. This is set to false by default. When this is
set to true it avoids discovering CRD if this CRD got created.

This solves the problem of waiting for each CRD to get
discovered when a Recipe consisting of one or more CRDs get
created.

Signed-off-by: AmitKumarDas <amit.das@mayadata.io>