### PR TITLE
fix(recipe): update labeling operation with fixes

### DIFF
--- a/pkg/recipe/labeling.go
+++ b/pkg/recipe/labeling.go
@@ -128,7 +128,10 @@ func (l *Labeling) labelOrUnset(
 	obj *unstructured.Unstructured,
 ) error {
 	var isInclude bool
-	for _, name := range l.Label.FilterByNames {
+	if len(l.Label.IncludeByNames) == 0 {
+		isInclude = true
+	}
+	for _, name := range l.Label.IncludeByNames {
 		if name == obj.GetName() {
 			isInclude = true
 			break
@@ -195,5 +198,10 @@ func (l *Labeling) labelAll() (*types.LabelResult, error) {
 // Run applyies the desired labels or unsets them
 // against the resource(s)
 func (l *Labeling) Run() (*types.LabelResult, error) {
+	if len(l.Label.ApplyLabels) == 0 {
+		return nil, errors.Errorf(
+			"Invalid label operation: Missing ApplyLabels",
+		)
+	}
 	return l.labelAll()
 }

--- a/types/recipe/label.go
+++ b/types/recipe/label.go
@@ -29,13 +29,15 @@ type Label struct {
 	// labeled
 	State *unstructured.Unstructured `json:"state"`
 
-	// Filter the resources by these names
+	// Include the resources by these names
 	//
 	// Optional
-	FilterByNames []string `json:"filterByNames,omitempty"`
+	IncludeByNames []string `json:"includeByNames,omitempty"`
 
 	// ApplyLabels represents the labels that need to be
-	// applied
+	// applied against the selected resources
+	//
+	// This is mandatory field
 	ApplyLabels map[string]string `json:"applyLabels"`
 
 	// AutoUnset removes the labels from the resources if


### PR DESCRIPTION
This handles the case when ApplyLabels field is not set.
Code results in error when ApplyLabels is empty.

All listed resources are included to be labeled if
IncludeByNames field is empty, since this is an optional
field.

Signed-off-by: AmitKumarDas <amit.das@mayadata.io>