### PR TITLE
fix(recipe): include ignoreDiscovery as a valid Recipe schema

### DIFF
--- a/types/recipe/apply.go
+++ b/types/recipe/apply.go
@@ -53,7 +53,7 @@ type Apply struct {
 	//
 	// NOTE:
 	//	This is only applicable for kind: CustomResourceDefinition
-	IgnoreDiscovery bool
+	IgnoreDiscovery bool `json:"ignoreDiscovery"`
 }
 
 // String implements the Stringer interface

--- a/types/recipe/create.go
+++ b/types/recipe/create.go
@@ -35,7 +35,7 @@ type Create struct {
 	//
 	// NOTE:
 	//	This is only applicable for kind: CustomResourceDefinition
-	IgnoreDiscovery bool
+	IgnoreDiscovery bool `json:"ignoreDiscovery"`
 }
 
 // String implements the Stringer interface

--- a/types/recipe/schema.go
+++ b/types/recipe/schema.go
@@ -50,6 +50,7 @@ var SupportedAbsolutePaths = []string{
 	"spec.tasks.[*].name",
 	"spec.tasks.[*].failFast.when",
 	"spec.tasks.[*].ignoreError",
+	"spec.tasks.[*].create.ignoreDiscovery",
 	"spec.tasks.[*].create.replicas",
 	"spec.tasks.[*].assert.stateCheck.stateCheckOperator",
 	"spec.tasks.[*].assert.stateCheck.count",
@@ -57,6 +58,8 @@ var SupportedAbsolutePaths = []string{
 	"spec.tasks.[*].assert.pathCheck.pathCheckOperator",
 	"spec.tasks.[*].assert.pathCheck.value",
 	"spec.tasks.[*].assert.pathCheck.dataType",
+	"spec.tasks.[*].apply.ignoreDiscovery",
+	"spec.tasks.[*].apply.replicas",
 }
 
 // UserAllowedPathPrefixes represent the nested field paths


### PR DESCRIPTION
This fixes the InvalidSchema issue faced while applying Recipe
custom resource in a Kubernetes cluster.

Signed-off-by: AmitKumarDas <amit.das@mayadata.io>